### PR TITLE
New usefull outputs to use with route53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+<a name="v0.5.0"></a>
+## [v0.5.0] - 2020-11-24
+
+- fix: Updated supported Terraform versions
+
+
 <a name="v0.4.0"></a>
 ## [v0.4.0] - 2020-09-08
 
@@ -33,7 +39,8 @@ All notable changes to this project will be documented in this file.
 - Adding API Gateway module
 
 
-[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/compare/v0.5.0...HEAD
+[v0.5.0]: https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/compare/v0.4.0...v0.5.0
 [v0.4.0]: https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ module "api_gateway" {
 | this\_apigatewayv2\_api\_id | The API identifier |
 | this\_apigatewayv2\_api\_mapping\_id | The API mapping identifier. |
 | this\_apigatewayv2\_target\_domain\_name | API GTW target domain name to use with route 53 |
-| this\_apigatewayv2\_target\_hosted\_id | API GTW hosted zone id to use with route 53 |
+| this\_apigatewayv2\_hosted\zone\_id | API GTW hosted zone id to use with route 53 |
 | this\_apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression | The API mapping selection expression for the domain name. |
 | this\_apigatewayv2\_domain\_name\_arn | The ARN of the domain name |
 | this\_apigatewayv2\_domain\_name\_configuration | The ARN of the domain name |

--- a/README.md
+++ b/README.md
@@ -163,12 +163,12 @@ module "api_gateway" {
 | this\_apigatewayv2\_api\_execution\_arn | The ARN prefix to be used in an aws\_lambda\_permission's source\_arn attribute or in an aws\_iam\_policy to authorize access to the @connections API. |
 | this\_apigatewayv2\_api\_id | The API identifier |
 | this\_apigatewayv2\_api\_mapping\_id | The API mapping identifier. |
-| this\_apigatewayv2\_target\_domain\_name | API GTW target domain name to use with route 53 |
-| this\_apigatewayv2\_hosted\_zone\_id | API GTW hosted zone id to use with route 53 |
-| this\_apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression | The API mapping selection expression for the domain name. |
+| this\_apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression | The API mapping selection expression for the domain name |
 | this\_apigatewayv2\_domain\_name\_arn | The ARN of the domain name |
-| this\_apigatewayv2\_domain\_name\_configuration | The ARN of the domain name |
+| this\_apigatewayv2\_domain\_name\_configuration | The domain name configuration |
+| this\_apigatewayv2\_domain\_name\_hosted\_zone\_id | The Amazon Route 53 Hosted Zone ID of the endpoint |
 | this\_apigatewayv2\_domain\_name\_id | The domain name identifier |
+| this\_apigatewayv2\_domain\_name\_target\_domain\_name | The target domain name |
 | this\_apigatewayv2\_vpc\_link\_arn | The VPC Link ARN |
 | this\_apigatewayv2\_vpc\_link\_id | The VPC Link identifier |
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ module "api_gateway" {
 | this\_apigatewayv2\_api\_id | The API identifier |
 | this\_apigatewayv2\_api\_mapping\_id | The API mapping identifier. |
 | this\_apigatewayv2\_target\_domain\_name | API GTW target domain name to use with route 53 |
-| this\_apigatewayv2\_hosted\zone\_id | API GTW hosted zone id to use with route 53 |
+| this\_apigatewayv2\_hosted\_zone\_id | API GTW hosted zone id to use with route 53 |
 | this\_apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression | The API mapping selection expression for the domain name. |
 | this\_apigatewayv2\_domain\_name\_arn | The ARN of the domain name |
 | this\_apigatewayv2\_domain\_name\_configuration | The ARN of the domain name |

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ module "api_gateway" {
 | this\_apigatewayv2\_api\_execution\_arn | The ARN prefix to be used in an aws\_lambda\_permission's source\_arn attribute or in an aws\_iam\_policy to authorize access to the @connections API. |
 | this\_apigatewayv2\_api\_id | The API identifier |
 | this\_apigatewayv2\_api\_mapping\_id | The API mapping identifier. |
+| this\_apigatewayv2\_target\_domain\_name | API GTW target domain name to use with route 53 |
+| this\_apigatewayv2\_target\_hosted\_id | API GTW hosted zone id to use with route 53 |
 | this\_apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression | The API mapping selection expression for the domain name. |
 | this\_apigatewayv2\_domain\_name\_arn | The ARN of the domain name |
 | this\_apigatewayv2\_domain\_name\_configuration | The ARN of the domain name |

--- a/examples/complete-http/README.md
+++ b/examples/complete-http/README.md
@@ -49,7 +49,10 @@ No input.
 | local\_filename | The filename of zip archive deployed (if deployment was from local) |
 | s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
 | this\_apigatewayv2\_api\_api\_endpoint | The URI of the API |
+| this\_apigatewayv2\_domain\_name\_configuration | The domain name configuration |
 | this\_apigatewayv2\_domain\_name\_id | The domain name identifier |
+| this\_apigatewayv2\_hosted\_zone\_id | The Amazon Route 53 Hosted Zone ID of the endpoint |
+| this\_apigatewayv2\_target\_domain\_name | The target domain name |
 | this\_lambda\_function\_arn | The ARN of the Lambda Function |
 | this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
 | this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |

--- a/examples/complete-http/outputs.tf
+++ b/examples/complete-http/outputs.tf
@@ -110,6 +110,21 @@ output "this_apigatewayv2_domain_name_id" {
   value       = module.api_gateway.this_apigatewayv2_domain_name_id
 }
 
+output "this_apigatewayv2_domain_name_configuration" {
+  description = "The domain name configuration"
+  value       = module.api_gateway.this_apigatewayv2_domain_name_configuration
+}
+
+output "this_apigatewayv2_target_domain_name" {
+  description = "The target domain name"
+  value       = module.api_gateway.this_apigatewayv2_domain_name_target_domain_name
+}
+
+output "this_apigatewayv2_hosted_zone_id" {
+  description = "The Amazon Route 53 Hosted Zone ID of the endpoint"
+  value       = module.api_gateway.this_apigatewayv2_domain_name_hosted_zone_id
+}
+
 # Route53 record
 output "api_fqdn" {
   description = "List of Route53 records"

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,12 +47,12 @@ output "this_apigatewayv2_domain_name_id" {
 
 output "this_apigatewayv2_target_domain_name" {
   description = "The ARN of the domain name"
-  value       = aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].target_domain_name
+  value       = element(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].target_domain_name,0)
 }
 
 output "this_apigatewayv2_hosted_zone_id" {
   description = "The ARN of the domain name"
-  value       = aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].hosted_zone_id
+  value       = element(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].hosted_zone_id,0)
 }
 output "this_apigatewayv2_domain_name_arn" {
   description = "The ARN of the domain name"

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,12 +47,12 @@ output "this_apigatewayv2_domain_name_id" {
 
 output "this_apigatewayv2_target_domain_name" {
   description = "The ARN of the domain name"
-  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, list("")),2)
+  value       = lookup(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0], list("")),2),"target_domain_name","")
 }
 
 output "this_apigatewayv2_hosted_zone_id" {
   description = "The ARN of the domain name"
-  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, list("")),1)
+  value       = lookup(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0], list("")),2),"hosted_zone_id","")
 }
 output "this_apigatewayv2_domain_name_arn" {
   description = "The ARN of the domain name"

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,12 +47,12 @@ output "this_apigatewayv2_domain_name_id" {
 
 output "this_apigatewayv2_target_domain_name" {
   description = "The ARN of the domain name"
-  value       = aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].target_domain_name
+  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, list("")), 4)
 }
 
 output "this_apigatewayv2_hosted_zone_id" {
   description = "The ARN of the domain name"
-  value       = aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].hosted_zone_id
+  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, list("")), 3)
 }
 output "this_apigatewayv2_domain_name_arn" {
   description = "The ARN of the domain name"

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,6 +45,15 @@ output "this_apigatewayv2_domain_name_id" {
   value       = element(concat(aws_apigatewayv2_domain_name.this.*.id, list("")), 0)
 }
 
+output "this_apigatewayv2_target_domain_name" {
+  description = "The ARN of the domain name"
+  value       = concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].target_domain_name
+}
+
+output "this_apigatewayv2_hosted_zone_id" {
+  description = "The ARN of the domain name"
+  value       = aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].hosted_zone_id
+}
 output "this_apigatewayv2_domain_name_arn" {
   description = "The ARN of the domain name"
   value       = element(concat(aws_apigatewayv2_domain_name.this.*.arn, list("")), 0)

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,12 +47,12 @@ output "this_apigatewayv2_domain_name_id" {
 
 output "this_apigatewayv2_target_domain_name" {
   description = "The ARN of the domain name"
-  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].target_domain_name, list("")),0)
+  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, list("")),2)
 }
 
 output "this_apigatewayv2_hosted_zone_id" {
   description = "The ARN of the domain name"
-  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].hosted_zone_id, list("")),0)
+  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, list("")),1)
 }
 output "this_apigatewayv2_domain_name_arn" {
   description = "The ARN of the domain name"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,93 +1,94 @@
 output "this_apigatewayv2_api_id" {
   description = "The API identifier"
-  value       = element(concat(aws_apigatewayv2_api.this.*.id, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_api.this.*.id, [""]), 0)
 }
 
 output "this_apigatewayv2_api_api_endpoint" {
   description = "The URI of the API"
-  value       = element(concat(aws_apigatewayv2_api.this.*.api_endpoint, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_api.this.*.api_endpoint, [""]), 0)
 }
 
 output "this_apigatewayv2_api_arn" {
   description = "The ARN of the API"
-  value       = element(concat(aws_apigatewayv2_api.this.*.arn, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_api.this.*.arn, [""]), 0)
 }
 
 output "this_apigatewayv2_api_execution_arn" {
   description = "The ARN prefix to be used in an aws_lambda_permission's source_arn attribute or in an aws_iam_policy to authorize access to the @connections API."
-  value       = element(concat(aws_apigatewayv2_api.this.*.execution_arn, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_api.this.*.execution_arn, [""]), 0)
 }
 
 # default stage
 output "default_apigatewayv2_stage_id" {
   description = "The default stage identifier"
-  value       = element(concat(aws_apigatewayv2_stage.default.*.id, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_stage.default.*.id, [""]), 0)
 }
 
 output "default_apigatewayv2_stage_arn" {
   description = "The default stage ARN"
-  value       = element(concat(aws_apigatewayv2_stage.default.*.arn, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_stage.default.*.arn, [""]), 0)
 }
 
 output "default_apigatewayv2_stage_execution_arn" {
   description = "The ARN prefix to be used in an aws_lambda_permission's source_arn attribute or in an aws_iam_policy to authorize access to the @connections API."
-  value       = element(concat(aws_apigatewayv2_stage.default.*.execution_arn, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_stage.default.*.execution_arn, [""]), 0)
 }
 
 output "default_apigatewayv2_stage_invoke_url" {
   description = "The URL to invoke the API pointing to the stage"
-  value       = element(concat(aws_apigatewayv2_stage.default.*.invoke_url, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_stage.default.*.invoke_url, [""]), 0)
 }
 
 # domain name
 output "this_apigatewayv2_domain_name_id" {
   description = "The domain name identifier"
-  value       = element(concat(aws_apigatewayv2_domain_name.this.*.id, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_domain_name.this.*.id, [""]), 0)
 }
 
-output "this_apigatewayv2_target_domain_name" {
-  description = "The ARN of the domain name"
-  value       = lookup(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0], list("")),2),"target_domain_name","")
-}
-
-output "this_apigatewayv2_hosted_zone_id" {
-  description = "The ARN of the domain name"
-  value       = lookup(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0], list("")),2),"hosted_zone_id","")
-}
 output "this_apigatewayv2_domain_name_arn" {
   description = "The ARN of the domain name"
-  value       = element(concat(aws_apigatewayv2_domain_name.this.*.arn, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_domain_name.this.*.arn, [""]), 0)
 }
 
 output "this_apigatewayv2_domain_name_api_mapping_selection_expression" {
-  description = "The API mapping selection expression for the domain name."
-  value       = element(concat(aws_apigatewayv2_domain_name.this.*.api_mapping_selection_expression, list("")), 0)
+  description = "The API mapping selection expression for the domain name"
+  value       = element(concat(aws_apigatewayv2_domain_name.this.*.api_mapping_selection_expression, [""]), 0)
 }
 
 output "this_apigatewayv2_domain_name_configuration" {
-  description = "The ARN of the domain name"
-  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, list("")), 0)
+  description = "The domain name configuration"
+  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0)
+}
+
+output "this_apigatewayv2_domain_name_target_domain_name" {
+  description = "The target domain name"
+  value       = var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "target_domain_name","") : ""
+}
+
+output "this_apigatewayv2_domain_name_hosted_zone_id" {
+  description = "The Amazon Route 53 Hosted Zone ID of the endpoint"
+  value       = var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "hosted_zone_id","") : ""
 }
 
 # api mapping
 output "this_apigatewayv2_api_mapping_id" {
   description = "The API mapping identifier."
-  value       = element(concat(aws_apigatewayv2_api_mapping.this.*.id, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_api_mapping.this.*.id, [""]), 0)
 }
 
 # route
 # output "this_apigatewayv2_route_id" {
 #  description = "The default route identifier."
-#  value       = element(concat(aws_apigatewayv2_route.this.*.id, list("")), 0)
+#  value       = element(concat(aws_apigatewayv2_route.this.*.id, [""]), 0)
 # }
 
 # vpc link
 output "this_apigatewayv2_vpc_link_id" {
   description = "The VPC Link identifier"
-  value       = element(concat(aws_apigatewayv2_vpc_link.this.*.id, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_vpc_link.this.*.id, [""]), 0)
 }
 
 output "this_apigatewayv2_vpc_link_arn" {
   description = "The VPC Link ARN"
-  value       = element(concat(aws_apigatewayv2_vpc_link.this.*.arn, list("")), 0)
+  value       = element(concat(aws_apigatewayv2_vpc_link.this.*.arn, [""]), 0)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,12 +47,12 @@ output "this_apigatewayv2_domain_name_id" {
 
 output "this_apigatewayv2_target_domain_name" {
   description = "The ARN of the domain name"
-  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, list("")), 4)
+  value       = aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].target_domain_name
 }
 
 output "this_apigatewayv2_hosted_zone_id" {
   description = "The ARN of the domain name"
-  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, list("")), 3)
+  value       = aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].hosted_zone_id
 }
 output "this_apigatewayv2_domain_name_arn" {
   description = "The ARN of the domain name"

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,7 +48,7 @@ output "this_apigatewayv2_domain_name_id" {
 output "this_apigatewayv2_target_domain_name" {
   description = "The ARN of the domain name"
   value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].target_domain_name, list("")),0)
-})
+}
 
 output "this_apigatewayv2_hosted_zone_id" {
   description = "The ARN of the domain name"

--- a/outputs.tf
+++ b/outputs.tf
@@ -62,12 +62,12 @@ output "this_apigatewayv2_domain_name_configuration" {
 
 output "this_apigatewayv2_domain_name_target_domain_name" {
   description = "The target domain name"
-  value       = var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "target_domain_name","") : ""
+  value       = var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "target_domain_name", "") : ""
 }
 
 output "this_apigatewayv2_domain_name_hosted_zone_id" {
   description = "The Amazon Route 53 Hosted Zone ID of the endpoint"
-  value       = var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "hosted_zone_id","") : ""
+  value       = var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "hosted_zone_id", "") : ""
 }
 
 # api mapping

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,7 +47,7 @@ output "this_apigatewayv2_domain_name_id" {
 
 output "this_apigatewayv2_target_domain_name" {
   description = "The ARN of the domain name"
-  value       = concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].target_domain_name
+  value       = aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].target_domain_name
 }
 
 output "this_apigatewayv2_hosted_zone_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,12 +47,12 @@ output "this_apigatewayv2_domain_name_id" {
 
 output "this_apigatewayv2_target_domain_name" {
   description = "The ARN of the domain name"
-  value       = element(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].target_domain_name,0)
-}
+  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].target_domain_name, list("")),0)
+})
 
 output "this_apigatewayv2_hosted_zone_id" {
   description = "The ARN of the domain name"
-  value       = element(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].hosted_zone_id,0)
+  value       = element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration[0].hosted_zone_id, list("")),0)
 }
 output "this_apigatewayv2_domain_name_arn" {
   description = "The ARN of the domain name"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
the outputs this_apigatewayv2_target_domain_name and this_apigatewayv2_hosted_zone_id was added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
 to use a custom domain name with route 53

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
 all ok!!!, 💯 

## How Has This Been Tested?
  manual hard test with my own infraestructure
