### PR TITLE
fix: default API Gateway integration method

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -121,7 +121,7 @@ resource "aws_apigatewayv2_integration" "this" {
   description      = lookup(each.value, "description", null)
 
   connection_type    = lookup(each.value, "connection_type", "INTERNET")
-  integration_method = lookup(each.value, "integration_method", "ANY") # Q: Where this is used in API gateway? I can't see it in UI.
+  integration_method = lookup(each.value, "integration_method", "POST")
   integration_uri    = lookup(each.value, "lambda_arn", null)
 
   payload_format_version = lookup(each.value, "payload_format_version", null)


### PR DESCRIPTION
## Description
Integration method `ANY` is not supported. The reason you can't see it on the AWS Console is because it always defaults to `POST`.
The has nothing to do with the HTTP method used to call the API and is just how API Gateway calls the Lambda API (the handler will still receive the correct method).

## Motivation and Context
Lambda proxy integrations were broken upon first deployment of our services, but worked as soon as they were edited and saved in the console (without making any changes). I investigated and realised that it's because an unsupported integration method was used and upon editing and saving the console automatically changed this to `POST`.

## Breaking Changes
No

## How Has This Been Tested?
Currently used in production in the company where I work.
