### PR TITLE
fix: Integration URI is not always a lambda_arn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,7 @@ resource "aws_apigatewayv2_integration" "this" {
 
   connection_type    = lookup(each.value, "connection_type", "INTERNET")
   integration_method = lookup(each.value, "integration_method", "ANY") # Q: Where this is used in API gateway? I can't see it in UI.
-  integration_uri    = lookup(each.value, "lambda_arn", null)
+  integration_uri    = lookup(each.value, "lambda_arn", lookup(each.value, "integration_uri", null))
 
   payload_format_version = lookup(each.value, "payload_format_version", null)
   timeout_milliseconds   = lookup(each.value, "timeout_milliseconds", null)


### PR DESCRIPTION
## Description
the integration uri must not always be lambda

## Motivation and Context
currently you would use "lambda_arn" attribute also for http-proxy integrations

## Breaking Changes
-

## How Has This Been Tested?
changed it locally within the cached module and executed my terraform successfully 
