### PR TITLE
feat: support authorization_type and authorizer_id on routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ module "api_gateway" {
 
 ## Examples
 
-- [Complete HTTP](https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/tree/master/examples/complete-http) - Create API Gateway, domain name, stage and other resources in various combinations
+- [Complete HTTP](https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/tree/master/examples/complete-http) - Create API Gateway, authorizer, domain name, stage and other resources in various combinations
 - [HTTP with VPC Link](https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/tree/master/examples/vpc-link-http) - Create API Gateway with VPC link to access private resources
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,9 @@ resource "aws_apigatewayv2_route" "this" {
 
   api_id    = aws_apigatewayv2_api.this[0].id
   route_key = each.key
+  authorization_type = lookup(each.value, "authorization_type", "NONE")
+  authorizer_id = lookup(each.value, "authorizer_id", null)
+
   target    = "integrations/${aws_apigatewayv2_integration.this[each.key].id}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -110,10 +110,18 @@ resource "aws_apigatewayv2_route" "this" {
 
   api_id    = aws_apigatewayv2_api.this[0].id
   route_key = each.key
-  authorization_type = lookup(each.value, "authorization_type", "NONE")
-  authorizer_id = lookup(each.value, "authorizer_id", null)
 
-  target    = "integrations/${aws_apigatewayv2_integration.this[each.key].id}"
+  api_key_required                    = lookup(each.value, "api_key_required", null)
+  authorization_type                  = lookup(each.value, "authorization_type", "NONE")
+  authorizer_id                       = lookup(each.value, "authorizer_id", null)
+  model_selection_expression          = lookup(each.value, "model_selection_expression", null)
+  operation_name                      = lookup(each.value, "operation_name", null)
+  route_response_selection_expression = lookup(each.value, "route_response_selection_expression", null)
+  target                              = "integrations/${aws_apigatewayv2_integration.this[each.key].id}"
+
+  # Not sure what structure is allowed for these arguments...
+  #  authorization_scopes = lookup(each.value, "authorization_scopes", null)
+  #  request_models  = lookup(each.value, "request_models", null)
 }
 
 resource "aws_apigatewayv2_integration" "this" {


### PR DESCRIPTION
## Description
Adds support for setting `authorization_type` and `authorizer_id` on the `aws_apigatewayv2_route` resource, like so:

```
integrations = {
    "GET /some-route" = {
      lambda_arn = module.some_function.this_lambda_function_arn
      payload_format_version = "2.0"
      authorization_type = "CUSTOM"
      authorizer_id = aws_apigatewayv2_authorizer.some_authorizer.id 
    }
  }
  ```

## Motivation and Context
This module is helpful but limited by the lack of support for custom authorizers. This commit isn't perfect - it requires you to create an `aws_apigatewayv2_authorizer` independently, and then reference the id, but it's also immediately useful. If this isn't sufficient to merge, please let me know what you'd like to see in a commit and I'll see if I can match those expectations.

Defaults are set to what `aws_apigatewayv2_route` expects ("NONE", and null respectively).

## Breaking Changes
None that I know of, but I haven't committed to these modules before, so merger beware!

## How Has This Been Tested?
I tested this on a private source repository, and successfully deployed more or less the above example. I also tested deploying without these new parameters, successfully (observing authorization_type being set to NONE and authorizer_id being set to null).