### PR TITLE
feat: Added support for mTLS and the ability to disable default endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ module "api_gateway" {
 | default\_stage\_access\_log\_format | Default stage's single line format of the access logs of data, as specified by selected $context variables. | `string` | `null` | no |
 | default\_stage\_tags | A mapping of tags to assign to the default stage resource. | `map(string)` | `{}` | no |
 | description | The description of the API. | `string` | `null` | no |
+| disable\_execute\_api\_endpoint | Whether clients can invoke the API by using the default execute-api endpoint. To require that clients use a custom domain name to invoke the API, disable the default endpoint | `string` | `true` | no |
 | domain\_name | The domain name to use for API gateway | `string` | `null` | no |
 | domain\_name\_certificate\_arn | The ARN of an AWS-managed certificate that will be used by the endpoint for the domain name | `string` | `null` | no |
 | domain\_name\_tags | A mapping of tags to assign to API domain name resource. | `map(string)` | `{}` | no |
@@ -148,6 +149,8 @@ module "api_gateway" {
 | subnet\_ids | Subnet IDs for the VPC Link | `list(string)` | `[]` | no |
 | tags | A mapping of tags to assign to API gateway resources. | `map(string)` | `{}` | no |
 | target | Part of quick create. Quick create produces an API with an integration, a default catch-all route, and a default stage which is configured to automatically deploy changes. For HTTP integrations, specify a fully qualified URL. For Lambda integrations, specify a function ARN. The type of the integration will be HTTP\_PROXY or AWS\_PROXY, respectively. Applicable for HTTP APIs. | `string` | `null` | no |
+| truststore\_uri | An Amazon S3 URL that specifies the truststore for mutual TLS authentication | `string` | `null` | yes |
+| truststore\_version | The version of the S3 object that contains the truststore. | `string` | `null` | yes |
 | vpc\_link\_tags | A map of tags to add to the VPC Link | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ resource "aws_apigatewayv2_api" "this" {
 
   route_selection_expression   = var.route_selection_expression
   api_key_selection_expression = var.api_key_selection_expression
+  disable_execute_api_endpoint = var.disable_execute_api_endpoint
 
   /* Start of quick create */
   route_key       = var.route_key
@@ -42,6 +43,11 @@ resource "aws_apigatewayv2_domain_name" "this" {
     certificate_arn = var.domain_name_certificate_arn
     endpoint_type   = "REGIONAL"
     security_policy = "TLS_1_2"
+  }
+
+  mutual_tls_authentication {
+    truststore_uri     = var.truststore_uri
+    truststore_version = var.truststore_version
   }
 
   tags = merge(var.domain_name_tags, var.tags)

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,12 @@ variable "description" {
   default     = null
 }
 
+variable "disable_execute_api_endpoint" {
+  type        = string
+  default     = false
+  description = "Whether clients can invoke the API by using the default execute-api endpoint. To require that clients use a custom domain name to invoke the API, disable the default endpoint"
+}
+
 variable "protocol_type" {
   description = "The API protocol. Valid values: HTTP, WEBSOCKET"
   type        = string
@@ -160,6 +166,18 @@ variable "domain_name_tags" {
   description = "A mapping of tags to assign to API domain name resource."
   type        = map(string)
   default     = {}
+}
+
+variable "truststore_uri" {
+  description = "An Amazon S3 URL that specifies the truststore for mutual TLS authentication"
+  type        = string
+  default     = null
+}
+
+variable "truststore_version" {
+  description = "The version of the S3 object that contains the truststore."
+  type        = string
+  default     = null
 }
 
 ####


### PR DESCRIPTION
## Description
I have added the option to have mutual TLS in the api gateway domain and also the possibility to disable the default endpoint as does not require mutual TLS. 

https://aws.amazon.com/blogs/compute/introducing-mutual-tls-authentication-for-amazon-api-gateway/

## Motivation and Context
It gives the developer the option to enable mTLS and disable the non mTLS default endpoint
Closes https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/issues/12

## Breaking Changes
It does not introduce any breaking change

## How Has This Been Tested?
Tested in my personal environment