### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,32 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
 
+# Terraform lockfile
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Zip archive
 *.zip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.39.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ module "api_gateway" {
 |------|---------|
 | aws | >= 2.59, < 4.0 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_apigatewayv2_api](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_api) |
+| [aws_apigatewayv2_api_mapping](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_api_mapping) |
+| [aws_apigatewayv2_domain_name](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_domain_name) |
+| [aws_apigatewayv2_integration](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_integration) |
+| [aws_apigatewayv2_route](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_route) |
+| [aws_apigatewayv2_stage](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_stage) |
+| [aws_apigatewayv2_vpc_link](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_vpc_link) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -132,7 +148,7 @@ module "api_gateway" {
 | create\_routes\_and\_integrations | Whether to create routes and integrations resources | `bool` | `true` | no |
 | create\_vpc\_link | Whether to create VPC link resource | `bool` | `false` | no |
 | credentials\_arn | Part of quick create. Specifies any credentials required for the integration. Applicable for HTTP APIs. | `string` | `null` | no |
-| default\_stage\_access\_log\_destination\_arn | Default stage's ARN of the CloudWatch Logs log group to receive access logs. Any trailing :\* is trimmed from the ARN. | `string` | `null` | no |
+| default\_stage\_access\_log\_destination\_arn | Default stage's ARN of the CloudWatch Logs log group to receive access logs. Any trailing :* is trimmed from the ARN. | `string` | `null` | no |
 | default\_stage\_access\_log\_format | Default stage's single line format of the access logs of data, as specified by selected $context variables. | `string` | `null` | no |
 | default\_stage\_tags | A mapping of tags to assign to the default stage resource. | `map(string)` | `{}` | no |
 | description | The description of the API. | `string` | `null` | no |
@@ -169,7 +185,6 @@ module "api_gateway" {
 | this\_apigatewayv2\_domain\_name\_id | The domain name identifier |
 | this\_apigatewayv2\_vpc\_link\_arn | The VPC Link ARN |
 | this\_apigatewayv2\_vpc\_link\_id | The VPC Link identifier |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ No Modules.
 
 | Name |
 |------|
-| [aws_apigatewayv2_api](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_api) |
 | [aws_apigatewayv2_api_mapping](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_api_mapping) |
+| [aws_apigatewayv2_api](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_api) |
 | [aws_apigatewayv2_domain_name](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_domain_name) |
 | [aws_apigatewayv2_integration](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_integration) |
 | [aws_apigatewayv2_route](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/apigatewayv2_route) |

--- a/examples/complete-http/README.md
+++ b/examples/complete-http/README.md
@@ -28,6 +28,25 @@ No requirements.
 | null | n/a |
 | random | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| acm | terraform-aws-modules/acm/aws | ~> 2.0 |
+| api_gateway | ../../ |  |
+| lambda_function | terraform-aws-modules/lambda/aws | ~> 1.0 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
+| [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) |
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) |
+| [null_data_source](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) |
+| [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -59,5 +78,4 @@ No input.
 | this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
 | this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
 | this\_lambda\_layer\_version | The Lambda Layer version |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/vpc-link-http/README.md
+++ b/examples/vpc-link-http/README.md
@@ -27,6 +27,24 @@ No requirements.
 | null | n/a |
 | random | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| api_gateway | ../../ |  |
+| api_gateway_security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
+| lambda_function | terraform-aws-modules/lambda/aws | ~> 1.0 |
+| lambda_security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
+| vpc | terraform-aws-modules/vpc/aws |  ~> 2.0 |
+
+## Resources
+
+| Name |
+|------|
+| [null_data_source](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) |
+| [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -38,5 +56,4 @@ No input.
 | this\_apigatewayv2\_api\_endpoint | The URI of the API |
 | this\_apigatewayv2\_vpc\_link\_arn | The ARN of the VPC Link |
 | this\_apigatewayv2\_vpc\_link\_id | The identifier of the VPC Link |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
