### PR TITLE
fix: bump min supported version due to types unsupported on current

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ module "api_gateway" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.59 |
 
 ## Providers

--- a/examples/complete-http/README.md
+++ b/examples/complete-http/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.59 |
 | null | >= 2.0 |
 | random | >= 2.0 |

--- a/examples/complete-http/README.md
+++ b/examples/complete-http/README.md
@@ -39,7 +39,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | acm | terraform-aws-modules/acm/aws | ~> 2.0 |
 | api_gateway | ../../ |  |
-| lambda_function | terraform-aws-modules/lambda/aws | ~> 1.0 |
+| lambda_function | terraform-aws-modules/lambda/aws | 1.38 |
 
 ## Resources
 

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -160,7 +160,7 @@ data "null_data_source" "downloaded_package" {
 
 module "lambda_function" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.0"
+  version = "1.38"
 
   function_name = "${random_pet.this.id}-lambda"
   description   = "My awesome lambda function"

--- a/examples/complete-http/versions.tf
+++ b/examples/complete-http/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 2.59"

--- a/examples/vpc-link-http/README.md
+++ b/examples/vpc-link-http/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.59 |
 | null | >= 2.0 |
 | random | >= 2.0 |

--- a/examples/vpc-link-http/README.md
+++ b/examples/vpc-link-http/README.md
@@ -38,7 +38,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | api_gateway | ../../ |  |
 | api_gateway_security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
-| lambda_function | terraform-aws-modules/lambda/aws | ~> 1.0 |
+| lambda_function | terraform-aws-modules/lambda/aws | 1.38 |
 | lambda_security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
 | vpc | terraform-aws-modules/vpc/aws |  ~> 2.0 |
 

--- a/examples/vpc-link-http/main.tf
+++ b/examples/vpc-link-http/main.tf
@@ -119,7 +119,7 @@ data "null_data_source" "downloaded_package" {
 
 module "lambda_function" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.0"
+  version = "1.38"
 
   function_name = "${random_pet.this.id}-lambda"
   description   = "My awesome lambda function"

--- a/examples/vpc-link-http/versions.tf
+++ b/examples/vpc-link-http/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = ">= 2.59"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = ">= 2.59"


### PR DESCRIPTION
## Description
- bump min supported version due to types unsupported on current

## Motivation and Context
- get static checks back to passing state

## Breaking Changes
- no

## How Has This Been Tested?
- ci-cd static checks
