### PR TITLE
fix: Remove workaround related to passthrough_behavior for older providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ module "api_gateway" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.26 |
-| aws | >= 2.59 |
+| aws | >= 3.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.59 |
+| aws | >= 3.3.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -137,12 +137,6 @@ resource "aws_apigatewayv2_integration" "this" {
 
   payload_format_version = lookup(each.value, "payload_format_version", null)
   timeout_milliseconds   = lookup(each.value, "timeout_milliseconds", null)
-
-  # Due to open issue - https://github.com/terraform-providers/terraform-provider-aws/issues/11148#issuecomment-619160589
-  # Bug in terraform-aws-provider with perpetual diff
-  lifecycle {
-    ignore_changes = [passthrough_behavior]
-  }
 }
 
 # VPC Link (Private API)

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.26"
 
   required_providers {
-    aws = ">= 2.59"
+    aws = ">= 3.3.0"
   }
 }


### PR DESCRIPTION
## Description
Removing old workaround that is no longer needed.

## Motivation and Context
The issue that this workaround resolves has been fixed in aws 3.3.0 and newer versions of terraform don't allow you to set lifecycle ignores for a property that isn't specified as far as I can tell. 

The error is:
```
Error: expected passthrough_behavior to be one of [WHEN_NO_MATCH NEVER WHEN_NO_TEMPLATES], got
```

The issue is:
https://github.com/terraform-providers/terraform-provider-aws/issues/11148#issuecomment-619160589

## Breaking Changes
This update forces users to upgrade their version of the AWS provider from 2.59 to at least 3.3.0.

## How Has This Been Tested?
I have tested this locally.