### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.47.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -108,85 +108,85 @@ module "api_gateway" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 3.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.3.0 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_apigatewayv2_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api) |
-| [aws_apigatewayv2_api_mapping](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api_mapping) |
-| [aws_apigatewayv2_domain_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_domain_name) |
-| [aws_apigatewayv2_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_integration) |
-| [aws_apigatewayv2_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_route) |
-| [aws_apigatewayv2_stage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_stage) |
-| [aws_apigatewayv2_vpc_link](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_vpc_link) |
+| Name | Type |
+|------|------|
+| [aws_apigatewayv2_api.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api) | resource |
+| [aws_apigatewayv2_api_mapping.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api_mapping) | resource |
+| [aws_apigatewayv2_domain_name.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_domain_name) | resource |
+| [aws_apigatewayv2_integration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_integration) | resource |
+| [aws_apigatewayv2_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_route) | resource |
+| [aws_apigatewayv2_stage.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_stage) | resource |
+| [aws_apigatewayv2_vpc_link.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_vpc_link) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| api\_key\_selection\_expression | An API key selection expression. Valid values: $context.authorizer.usageIdentifierKey, $request.header.x-api-key. | `string` | `"$request.header.x-api-key"` | no |
-| api\_version | A version identifier for the API | `string` | `null` | no |
-| body | An OpenAPI specification that defines the set of routes and integrations to create as part of the HTTP APIs. Supported only for HTTP APIs. | `string` | `null` | no |
-| cors\_configuration | The cross-origin resource sharing (CORS) configuration. Applicable for HTTP APIs. | `any` | `{}` | no |
-| create | Controls if API Gateway resources should be created | `bool` | `true` | no |
-| create\_api\_domain\_name | Whether to create API domain name resource | `bool` | `true` | no |
-| create\_api\_gateway | Whether to create API Gateway | `bool` | `true` | no |
-| create\_default\_stage | Whether to create default stage | `bool` | `true` | no |
-| create\_default\_stage\_api\_mapping | Whether to create default stage API mapping | `bool` | `true` | no |
-| create\_routes\_and\_integrations | Whether to create routes and integrations resources | `bool` | `true` | no |
-| create\_vpc\_link | Whether to create VPC links | `bool` | `true` | no |
-| credentials\_arn | Part of quick create. Specifies any credentials required for the integration. Applicable for HTTP APIs. | `string` | `null` | no |
-| default\_stage\_access\_log\_destination\_arn | Default stage's ARN of the CloudWatch Logs log group to receive access logs. Any trailing :* is trimmed from the ARN. | `string` | `null` | no |
-| default\_stage\_access\_log\_format | Default stage's single line format of the access logs of data, as specified by selected $context variables. | `string` | `null` | no |
-| default\_stage\_tags | A mapping of tags to assign to the default stage resource. | `map(string)` | `{}` | no |
-| description | The description of the API. | `string` | `null` | no |
-| domain\_name | The domain name to use for API gateway | `string` | `null` | no |
-| domain\_name\_certificate\_arn | The ARN of an AWS-managed certificate that will be used by the endpoint for the domain name | `string` | `null` | no |
-| domain\_name\_tags | A mapping of tags to assign to API domain name resource. | `map(string)` | `{}` | no |
-| integrations | Map of API gateway routes with integrations | `map(any)` | `{}` | no |
-| name | The name of the API | `string` | `""` | no |
-| protocol\_type | The API protocol. Valid values: HTTP, WEBSOCKET | `string` | `"HTTP"` | no |
-| route\_key | Part of quick create. Specifies any route key. Applicable for HTTP APIs. | `string` | `null` | no |
-| route\_selection\_expression | The route selection expression for the API. | `string` | `"$request.method $request.path"` | no |
-| tags | A mapping of tags to assign to API gateway resources. | `map(string)` | `{}` | no |
-| target | Part of quick create. Quick create produces an API with an integration, a default catch-all route, and a default stage which is configured to automatically deploy changes. For HTTP integrations, specify a fully qualified URL. For Lambda integrations, specify a function ARN. The type of the integration will be HTTP\_PROXY or AWS\_PROXY, respectively. Applicable for HTTP APIs. | `string` | `null` | no |
-| vpc\_link\_tags | A map of tags to add to the VPC Link | `map(string)` | `{}` | no |
-| vpc\_links | Map of VPC Links details to create | `map(any)` | `{}` | no |
+| <a name="input_api_key_selection_expression"></a> [api\_key\_selection\_expression](#input\_api\_key\_selection\_expression) | An API key selection expression. Valid values: $context.authorizer.usageIdentifierKey, $request.header.x-api-key. | `string` | `"$request.header.x-api-key"` | no |
+| <a name="input_api_version"></a> [api\_version](#input\_api\_version) | A version identifier for the API | `string` | `null` | no |
+| <a name="input_body"></a> [body](#input\_body) | An OpenAPI specification that defines the set of routes and integrations to create as part of the HTTP APIs. Supported only for HTTP APIs. | `string` | `null` | no |
+| <a name="input_cors_configuration"></a> [cors\_configuration](#input\_cors\_configuration) | The cross-origin resource sharing (CORS) configuration. Applicable for HTTP APIs. | `any` | `{}` | no |
+| <a name="input_create"></a> [create](#input\_create) | Controls if API Gateway resources should be created | `bool` | `true` | no |
+| <a name="input_create_api_domain_name"></a> [create\_api\_domain\_name](#input\_create\_api\_domain\_name) | Whether to create API domain name resource | `bool` | `true` | no |
+| <a name="input_create_api_gateway"></a> [create\_api\_gateway](#input\_create\_api\_gateway) | Whether to create API Gateway | `bool` | `true` | no |
+| <a name="input_create_default_stage"></a> [create\_default\_stage](#input\_create\_default\_stage) | Whether to create default stage | `bool` | `true` | no |
+| <a name="input_create_default_stage_api_mapping"></a> [create\_default\_stage\_api\_mapping](#input\_create\_default\_stage\_api\_mapping) | Whether to create default stage API mapping | `bool` | `true` | no |
+| <a name="input_create_routes_and_integrations"></a> [create\_routes\_and\_integrations](#input\_create\_routes\_and\_integrations) | Whether to create routes and integrations resources | `bool` | `true` | no |
+| <a name="input_create_vpc_link"></a> [create\_vpc\_link](#input\_create\_vpc\_link) | Whether to create VPC links | `bool` | `true` | no |
+| <a name="input_credentials_arn"></a> [credentials\_arn](#input\_credentials\_arn) | Part of quick create. Specifies any credentials required for the integration. Applicable for HTTP APIs. | `string` | `null` | no |
+| <a name="input_default_stage_access_log_destination_arn"></a> [default\_stage\_access\_log\_destination\_arn](#input\_default\_stage\_access\_log\_destination\_arn) | Default stage's ARN of the CloudWatch Logs log group to receive access logs. Any trailing :* is trimmed from the ARN. | `string` | `null` | no |
+| <a name="input_default_stage_access_log_format"></a> [default\_stage\_access\_log\_format](#input\_default\_stage\_access\_log\_format) | Default stage's single line format of the access logs of data, as specified by selected $context variables. | `string` | `null` | no |
+| <a name="input_default_stage_tags"></a> [default\_stage\_tags](#input\_default\_stage\_tags) | A mapping of tags to assign to the default stage resource. | `map(string)` | `{}` | no |
+| <a name="input_description"></a> [description](#input\_description) | The description of the API. | `string` | `null` | no |
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name to use for API gateway | `string` | `null` | no |
+| <a name="input_domain_name_certificate_arn"></a> [domain\_name\_certificate\_arn](#input\_domain\_name\_certificate\_arn) | The ARN of an AWS-managed certificate that will be used by the endpoint for the domain name | `string` | `null` | no |
+| <a name="input_domain_name_tags"></a> [domain\_name\_tags](#input\_domain\_name\_tags) | A mapping of tags to assign to API domain name resource. | `map(string)` | `{}` | no |
+| <a name="input_integrations"></a> [integrations](#input\_integrations) | Map of API gateway routes with integrations | `map(any)` | `{}` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the API | `string` | `""` | no |
+| <a name="input_protocol_type"></a> [protocol\_type](#input\_protocol\_type) | The API protocol. Valid values: HTTP, WEBSOCKET | `string` | `"HTTP"` | no |
+| <a name="input_route_key"></a> [route\_key](#input\_route\_key) | Part of quick create. Specifies any route key. Applicable for HTTP APIs. | `string` | `null` | no |
+| <a name="input_route_selection_expression"></a> [route\_selection\_expression](#input\_route\_selection\_expression) | The route selection expression for the API. | `string` | `"$request.method $request.path"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to API gateway resources. | `map(string)` | `{}` | no |
+| <a name="input_target"></a> [target](#input\_target) | Part of quick create. Quick create produces an API with an integration, a default catch-all route, and a default stage which is configured to automatically deploy changes. For HTTP integrations, specify a fully qualified URL. For Lambda integrations, specify a function ARN. The type of the integration will be HTTP\_PROXY or AWS\_PROXY, respectively. Applicable for HTTP APIs. | `string` | `null` | no |
+| <a name="input_vpc_link_tags"></a> [vpc\_link\_tags](#input\_vpc\_link\_tags) | A map of tags to add to the VPC Link | `map(string)` | `{}` | no |
+| <a name="input_vpc_links"></a> [vpc\_links](#input\_vpc\_links) | Map of VPC Links details to create | `map(any)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| default\_apigatewayv2\_stage\_arn | The default stage ARN |
-| default\_apigatewayv2\_stage\_execution\_arn | The ARN prefix to be used in an aws\_lambda\_permission's source\_arn attribute or in an aws\_iam\_policy to authorize access to the @connections API. |
-| default\_apigatewayv2\_stage\_id | The default stage identifier |
-| default\_apigatewayv2\_stage\_invoke\_url | The URL to invoke the API pointing to the stage |
-| this\_apigatewayv2\_api\_api\_endpoint | The URI of the API |
-| this\_apigatewayv2\_api\_arn | The ARN of the API |
-| this\_apigatewayv2\_api\_execution\_arn | The ARN prefix to be used in an aws\_lambda\_permission's source\_arn attribute or in an aws\_iam\_policy to authorize access to the @connections API. |
-| this\_apigatewayv2\_api\_id | The API identifier |
-| this\_apigatewayv2\_api\_mapping\_id | The API mapping identifier. |
-| this\_apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression | The API mapping selection expression for the domain name |
-| this\_apigatewayv2\_domain\_name\_arn | The ARN of the domain name |
-| this\_apigatewayv2\_domain\_name\_configuration | The domain name configuration |
-| this\_apigatewayv2\_domain\_name\_hosted\_zone\_id | The Amazon Route 53 Hosted Zone ID of the endpoint |
-| this\_apigatewayv2\_domain\_name\_id | The domain name identifier |
-| this\_apigatewayv2\_domain\_name\_target\_domain\_name | The target domain name |
-| this\_apigatewayv2\_vpc\_link\_arn | The map of VPC Link ARNs |
-| this\_apigatewayv2\_vpc\_link\_id | The map of VPC Link identifiers |
+| <a name="output_default_apigatewayv2_stage_arn"></a> [default\_apigatewayv2\_stage\_arn](#output\_default\_apigatewayv2\_stage\_arn) | The default stage ARN |
+| <a name="output_default_apigatewayv2_stage_execution_arn"></a> [default\_apigatewayv2\_stage\_execution\_arn](#output\_default\_apigatewayv2\_stage\_execution\_arn) | The ARN prefix to be used in an aws\_lambda\_permission's source\_arn attribute or in an aws\_iam\_policy to authorize access to the @connections API. |
+| <a name="output_default_apigatewayv2_stage_id"></a> [default\_apigatewayv2\_stage\_id](#output\_default\_apigatewayv2\_stage\_id) | The default stage identifier |
+| <a name="output_default_apigatewayv2_stage_invoke_url"></a> [default\_apigatewayv2\_stage\_invoke\_url](#output\_default\_apigatewayv2\_stage\_invoke\_url) | The URL to invoke the API pointing to the stage |
+| <a name="output_this_apigatewayv2_api_api_endpoint"></a> [this\_apigatewayv2\_api\_api\_endpoint](#output\_this\_apigatewayv2\_api\_api\_endpoint) | The URI of the API |
+| <a name="output_this_apigatewayv2_api_arn"></a> [this\_apigatewayv2\_api\_arn](#output\_this\_apigatewayv2\_api\_arn) | The ARN of the API |
+| <a name="output_this_apigatewayv2_api_execution_arn"></a> [this\_apigatewayv2\_api\_execution\_arn](#output\_this\_apigatewayv2\_api\_execution\_arn) | The ARN prefix to be used in an aws\_lambda\_permission's source\_arn attribute or in an aws\_iam\_policy to authorize access to the @connections API. |
+| <a name="output_this_apigatewayv2_api_id"></a> [this\_apigatewayv2\_api\_id](#output\_this\_apigatewayv2\_api\_id) | The API identifier |
+| <a name="output_this_apigatewayv2_api_mapping_id"></a> [this\_apigatewayv2\_api\_mapping\_id](#output\_this\_apigatewayv2\_api\_mapping\_id) | The API mapping identifier. |
+| <a name="output_this_apigatewayv2_domain_name_api_mapping_selection_expression"></a> [this\_apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression](#output\_this\_apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression) | The API mapping selection expression for the domain name |
+| <a name="output_this_apigatewayv2_domain_name_arn"></a> [this\_apigatewayv2\_domain\_name\_arn](#output\_this\_apigatewayv2\_domain\_name\_arn) | The ARN of the domain name |
+| <a name="output_this_apigatewayv2_domain_name_configuration"></a> [this\_apigatewayv2\_domain\_name\_configuration](#output\_this\_apigatewayv2\_domain\_name\_configuration) | The domain name configuration |
+| <a name="output_this_apigatewayv2_domain_name_hosted_zone_id"></a> [this\_apigatewayv2\_domain\_name\_hosted\_zone\_id](#output\_this\_apigatewayv2\_domain\_name\_hosted\_zone\_id) | The Amazon Route 53 Hosted Zone ID of the endpoint |
+| <a name="output_this_apigatewayv2_domain_name_id"></a> [this\_apigatewayv2\_domain\_name\_id](#output\_this\_apigatewayv2\_domain\_name\_id) | The domain name identifier |
+| <a name="output_this_apigatewayv2_domain_name_target_domain_name"></a> [this\_apigatewayv2\_domain\_name\_target\_domain\_name](#output\_this\_apigatewayv2\_domain\_name\_target\_domain\_name) | The target domain name |
+| <a name="output_this_apigatewayv2_vpc_link_arn"></a> [this\_apigatewayv2\_vpc\_link\_arn](#output\_this\_apigatewayv2\_vpc\_link\_arn) | The map of VPC Link ARNs |
+| <a name="output_this_apigatewayv2_vpc_link_id"></a> [this\_apigatewayv2\_vpc\_link\_id](#output\_this\_apigatewayv2\_vpc\_link\_id) | The map of VPC Link identifiers |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete-http/README.md
+++ b/examples/complete-http/README.md
@@ -20,73 +20,73 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.1 |
-| aws | >= 2.59 |
-| null | >= 2.0 |
-| random | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.59 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.59 |
-| null | >= 2.0 |
-| random | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.59 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| acm | terraform-aws-modules/acm/aws | ~> 2.0 |
-| api_gateway | ../../ |  |
-| lambda_function | terraform-aws-modules/lambda/aws | ~> 1.0 |
-| step_function | terraform-aws-modules/step-functions/aws | ~> 1.0 |
+| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 2.0 |
+| <a name="module_api_gateway"></a> [api\_gateway](#module\_api\_gateway) | ../../ |  |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 1.0 |
+| <a name="module_step_function"></a> [step\_function](#module\_step\_function) | terraform-aws-modules/step-functions/aws | ~> 1.0 |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_apigatewayv2_authorizer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_authorizer) |
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
-| [aws_cognito_user_pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) |
-| [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) |
-| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) |
-| [null_data_source](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) |
-| [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [aws_apigatewayv2_authorizer.some_authorizer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_authorizer) | resource |
+| [aws_cloudwatch_log_group.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cognito_user_pool.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) | resource |
+| [aws_route53_record.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [null_data_source.downloaded_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| api\_endpoint | FQDN of an API endpoint |
-| api\_fqdn | List of Route53 records |
-| lambda\_cloudwatch\_log\_group\_arn | The ARN of the Cloudwatch Log Group |
-| lambda\_role\_arn | The ARN of the IAM role created for the Lambda Function |
-| lambda\_role\_name | The name of the IAM role created for the Lambda Function |
-| local\_filename | The filename of zip archive deployed (if deployment was from local) |
-| s3\_object | The map with S3 object data of zip archive deployed (if deployment was from S3) |
-| this\_apigatewayv2\_api\_api\_endpoint | The URI of the API |
-| this\_apigatewayv2\_domain\_name\_configuration | The domain name configuration |
-| this\_apigatewayv2\_domain\_name\_id | The domain name identifier |
-| this\_apigatewayv2\_hosted\_zone\_id | The Amazon Route 53 Hosted Zone ID of the endpoint |
-| this\_apigatewayv2\_target\_domain\_name | The target domain name |
-| this\_lambda\_function\_arn | The ARN of the Lambda Function |
-| this\_lambda\_function\_invoke\_arn | The Invoke ARN of the Lambda Function |
-| this\_lambda\_function\_kms\_key\_arn | The ARN for the KMS encryption key of Lambda Function |
-| this\_lambda\_function\_last\_modified | The date Lambda Function resource was last modified |
-| this\_lambda\_function\_name | The name of the Lambda Function |
-| this\_lambda\_function\_qualified\_arn | The ARN identifying your Lambda Function Version |
-| this\_lambda\_function\_source\_code\_hash | Base64-encoded representation of raw SHA-256 sum of the zip file |
-| this\_lambda\_function\_source\_code\_size | The size in bytes of the function .zip file |
-| this\_lambda\_function\_version | Latest published version of Lambda Function |
-| this\_lambda\_layer\_arn | The ARN of the Lambda Layer with version |
-| this\_lambda\_layer\_created\_date | The date Lambda Layer resource was created |
-| this\_lambda\_layer\_layer\_arn | The ARN of the Lambda Layer without version |
-| this\_lambda\_layer\_source\_code\_size | The size in bytes of the Lambda Layer .zip file |
-| this\_lambda\_layer\_version | The Lambda Layer version |
+| <a name="output_api_endpoint"></a> [api\_endpoint](#output\_api\_endpoint) | FQDN of an API endpoint |
+| <a name="output_api_fqdn"></a> [api\_fqdn](#output\_api\_fqdn) | List of Route53 records |
+| <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
+| <a name="output_lambda_role_arn"></a> [lambda\_role\_arn](#output\_lambda\_role\_arn) | The ARN of the IAM role created for the Lambda Function |
+| <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
+| <a name="output_local_filename"></a> [local\_filename](#output\_local\_filename) | The filename of zip archive deployed (if deployment was from local) |
+| <a name="output_s3_object"></a> [s3\_object](#output\_s3\_object) | The map with S3 object data of zip archive deployed (if deployment was from S3) |
+| <a name="output_this_apigatewayv2_api_api_endpoint"></a> [this\_apigatewayv2\_api\_api\_endpoint](#output\_this\_apigatewayv2\_api\_api\_endpoint) | The URI of the API |
+| <a name="output_this_apigatewayv2_domain_name_configuration"></a> [this\_apigatewayv2\_domain\_name\_configuration](#output\_this\_apigatewayv2\_domain\_name\_configuration) | The domain name configuration |
+| <a name="output_this_apigatewayv2_domain_name_id"></a> [this\_apigatewayv2\_domain\_name\_id](#output\_this\_apigatewayv2\_domain\_name\_id) | The domain name identifier |
+| <a name="output_this_apigatewayv2_hosted_zone_id"></a> [this\_apigatewayv2\_hosted\_zone\_id](#output\_this\_apigatewayv2\_hosted\_zone\_id) | The Amazon Route 53 Hosted Zone ID of the endpoint |
+| <a name="output_this_apigatewayv2_target_domain_name"></a> [this\_apigatewayv2\_target\_domain\_name](#output\_this\_apigatewayv2\_target\_domain\_name) | The target domain name |
+| <a name="output_this_lambda_function_arn"></a> [this\_lambda\_function\_arn](#output\_this\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_this_lambda_function_invoke_arn"></a> [this\_lambda\_function\_invoke\_arn](#output\_this\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |
+| <a name="output_this_lambda_function_kms_key_arn"></a> [this\_lambda\_function\_kms\_key\_arn](#output\_this\_lambda\_function\_kms\_key\_arn) | The ARN for the KMS encryption key of Lambda Function |
+| <a name="output_this_lambda_function_last_modified"></a> [this\_lambda\_function\_last\_modified](#output\_this\_lambda\_function\_last\_modified) | The date Lambda Function resource was last modified |
+| <a name="output_this_lambda_function_name"></a> [this\_lambda\_function\_name](#output\_this\_lambda\_function\_name) | The name of the Lambda Function |
+| <a name="output_this_lambda_function_qualified_arn"></a> [this\_lambda\_function\_qualified\_arn](#output\_this\_lambda\_function\_qualified\_arn) | The ARN identifying your Lambda Function Version |
+| <a name="output_this_lambda_function_source_code_hash"></a> [this\_lambda\_function\_source\_code\_hash](#output\_this\_lambda\_function\_source\_code\_hash) | Base64-encoded representation of raw SHA-256 sum of the zip file |
+| <a name="output_this_lambda_function_source_code_size"></a> [this\_lambda\_function\_source\_code\_size](#output\_this\_lambda\_function\_source\_code\_size) | The size in bytes of the function .zip file |
+| <a name="output_this_lambda_function_version"></a> [this\_lambda\_function\_version](#output\_this\_lambda\_function\_version) | Latest published version of Lambda Function |
+| <a name="output_this_lambda_layer_arn"></a> [this\_lambda\_layer\_arn](#output\_this\_lambda\_layer\_arn) | The ARN of the Lambda Layer with version |
+| <a name="output_this_lambda_layer_created_date"></a> [this\_lambda\_layer\_created\_date](#output\_this\_lambda\_layer\_created\_date) | The date Lambda Layer resource was created |
+| <a name="output_this_lambda_layer_layer_arn"></a> [this\_lambda\_layer\_layer\_arn](#output\_this\_lambda\_layer\_layer\_arn) | The ARN of the Lambda Layer without version |
+| <a name="output_this_lambda_layer_source_code_size"></a> [this\_lambda\_layer\_source\_code\_size](#output\_this\_lambda\_layer\_source\_code\_size) | The size in bytes of the Lambda Layer .zip file |
+| <a name="output_this_lambda_layer_version"></a> [this\_lambda\_layer\_version](#output\_this\_lambda\_layer\_version) | The Lambda Layer version |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/vpc-link-http/README.md
+++ b/examples/vpc-link-http/README.md
@@ -20,47 +20,47 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
-| aws | >= 2.59 |
-| null | >= 2.0 |
-| random | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.59 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| null | >= 2.0 |
-| random | >= 2.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| alb | terraform-aws-modules/alb/aws |  |
-| alb_security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
-| api_gateway | ../../ |  |
-| api_gateway_security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
-| lambda_function | terraform-aws-modules/lambda/aws | ~> 1.0 |
-| lambda_security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
-| vpc | terraform-aws-modules/vpc/aws |  ~> 2.0 |
+| <a name="module_alb"></a> [alb](#module\_alb) | terraform-aws-modules/alb/aws |  |
+| <a name="module_alb_security_group"></a> [alb\_security\_group](#module\_alb\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3.0 |
+| <a name="module_api_gateway"></a> [api\_gateway](#module\_api\_gateway) | ../../ |  |
+| <a name="module_api_gateway_security_group"></a> [api\_gateway\_security\_group](#module\_api\_gateway\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3.0 |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 1.0 |
+| <a name="module_lambda_security_group"></a> [lambda\_security\_group](#module\_lambda\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws |  ~> 2.0 |
 
 ## Resources
 
-| Name |
-|------|
-| [null_data_source](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) |
-| [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
-| [random_pet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) |
+| Name | Type |
+|------|------|
+| [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [null_data_source.downloaded_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this\_apigatewayv2\_api\_endpoint | The URI of the API |
-| this\_apigatewayv2\_vpc\_link\_arn | The ARN of the VPC Link |
-| this\_apigatewayv2\_vpc\_link\_id | The identifier of the VPC Link |
+| <a name="output_this_apigatewayv2_api_endpoint"></a> [this\_apigatewayv2\_api\_endpoint](#output\_this\_apigatewayv2\_api\_endpoint) | The URI of the API |
+| <a name="output_this_apigatewayv2_vpc_link_arn"></a> [this\_apigatewayv2\_vpc\_link\_arn](#output\_this\_apigatewayv2\_vpc\_link\_arn) | The ARN of the VPC Link |
+| <a name="output_this_apigatewayv2_vpc_link_id"></a> [this\_apigatewayv2\_vpc\_link\_id](#output\_this\_apigatewayv2\_vpc\_link\_id) | The identifier of the VPC Link |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
