### PR TITLE
feat: Add support for default_route_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ No modules.
 | <a name="input_create_routes_and_integrations"></a> [create\_routes\_and\_integrations](#input\_create\_routes\_and\_integrations) | Whether to create routes and integrations resources | `bool` | `true` | no |
 | <a name="input_create_vpc_link"></a> [create\_vpc\_link](#input\_create\_vpc\_link) | Whether to create VPC links | `bool` | `true` | no |
 | <a name="input_credentials_arn"></a> [credentials\_arn](#input\_credentials\_arn) | Part of quick create. Specifies any credentials required for the integration. Applicable for HTTP APIs. | `string` | `null` | no |
-| <a name="input_default_route_settings"></a> [default\_route\_settings](#input\_default\_route\_settings) | Settings for default route | `map(string)` | `null` | no |
+| <a name="input_default_route_settings"></a> [default\_route\_settings](#input\_default\_route\_settings) | Settings for default route | `map(string)` | `{}` | no |
 | <a name="input_default_stage_access_log_destination_arn"></a> [default\_stage\_access\_log\_destination\_arn](#input\_default\_stage\_access\_log\_destination\_arn) | Default stage's ARN of the CloudWatch Logs log group to receive access logs. Any trailing :* is trimmed from the ARN. | `string` | `null` | no |
 | <a name="input_default_stage_access_log_format"></a> [default\_stage\_access\_log\_format](#input\_default\_stage\_access\_log\_format) | Default stage's single line format of the access logs of data, as specified by selected $context variables. | `string` | `null` | no |
 | <a name="input_default_stage_tags"></a> [default\_stage\_tags](#input\_default\_stage\_tags) | A mapping of tags to assign to the default stage resource. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ No modules.
 | <a name="input_create_routes_and_integrations"></a> [create\_routes\_and\_integrations](#input\_create\_routes\_and\_integrations) | Whether to create routes and integrations resources | `bool` | `true` | no |
 | <a name="input_create_vpc_link"></a> [create\_vpc\_link](#input\_create\_vpc\_link) | Whether to create VPC links | `bool` | `true` | no |
 | <a name="input_credentials_arn"></a> [credentials\_arn](#input\_credentials\_arn) | Part of quick create. Specifies any credentials required for the integration. Applicable for HTTP APIs. | `string` | `null` | no |
-| <a name="input_default_route_settings"></a> [default\_route\_settings](#input\_default\_route\_settings) | Settings for default route | `map(string)` | `{}` | no |
+| <a name="input_default_route_settings"></a> [default\_route\_settings](#input\_default\_route\_settings) | Settings for default route | `map(string)` | `{}` | no |
 | <a name="input_default_stage_access_log_destination_arn"></a> [default\_stage\_access\_log\_destination\_arn](#input\_default\_stage\_access\_log\_destination\_arn) | Default stage's ARN of the CloudWatch Logs log group to receive access logs. Any trailing :* is trimmed from the ARN. | `string` | `null` | no |
 | <a name="input_default_stage_access_log_format"></a> [default\_stage\_access\_log\_format](#input\_default\_stage\_access\_log\_format) | Default stage's single line format of the access logs of data, as specified by selected $context variables. | `string` | `null` | no |
 | <a name="input_default_stage_tags"></a> [default\_stage\_tags](#input\_default\_stage\_tags) | A mapping of tags to assign to the default stage resource. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ No modules.
 | <a name="input_create_routes_and_integrations"></a> [create\_routes\_and\_integrations](#input\_create\_routes\_and\_integrations) | Whether to create routes and integrations resources | `bool` | `true` | no |
 | <a name="input_create_vpc_link"></a> [create\_vpc\_link](#input\_create\_vpc\_link) | Whether to create VPC links | `bool` | `true` | no |
 | <a name="input_credentials_arn"></a> [credentials\_arn](#input\_credentials\_arn) | Part of quick create. Specifies any credentials required for the integration. Applicable for HTTP APIs. | `string` | `null` | no |
+| <a name="input_default_route_settings"></a> [default\_route\_settings](#input\_default\_route\_settings) | Settings for default route | `map(string)` | `null` | no |
 | <a name="input_default_stage_access_log_destination_arn"></a> [default\_stage\_access\_log\_destination\_arn](#input\_default\_stage\_access\_log\_destination\_arn) | Default stage's ARN of the CloudWatch Logs log group to receive access logs. Any trailing :* is trimmed from the ARN. | `string` | `null` | no |
 | <a name="input_default_stage_access_log_format"></a> [default\_stage\_access\_log\_format](#input\_default\_stage\_access\_log\_format) | Default stage's single line format of the access logs of data, as specified by selected $context variables. | `string` | `null` | no |
 | <a name="input_default_stage_tags"></a> [default\_stage\_tags](#input\_default\_stage\_tags) | A mapping of tags to assign to the default stage resource. | `map(string)` | `{}` | no |

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -44,6 +44,12 @@ module "api_gateway" {
   default_stage_access_log_destination_arn = aws_cloudwatch_log_group.logs.arn
   default_stage_access_log_format          = "$context.identity.sourceIp - - [$context.requestTime] \"$context.httpMethod $context.routeKey $context.protocol\" $context.status $context.responseLength $context.requestId $context.integrationErrorMessage"
 
+  default_route_settings = {
+    detailed_metrics_enabled = true
+    throttling_burst_limit   = 100
+    throttling_rate_limit    = 100
+  }
+
   integrations = {
     "ANY /" = {
       lambda_arn             = module.lambda_function.this_lambda_function_arn

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ resource "aws_apigatewayv2_stage" "default" {
     content {
       data_trace_enabled       = lookup(default_route_settings.value, "data_trace_enabled", false)
       detailed_metrics_enabled = lookup(default_route_settings.value, "detailed_metrics_enabled", false)
-      logging_level            = lookup(default_route_settings.value, "logging_level", "OFF")
+      logging_level            = lookup(default_route_settings.value, "logging_level", null)
       throttling_burst_limit   = lookup(default_route_settings.value, "throttling_burst_limit", null)
       throttling_rate_limit    = lookup(default_route_settings.value, "throttling_rate_limit", null)
     }

--- a/main.tf
+++ b/main.tf
@@ -73,16 +73,16 @@ resource "aws_apigatewayv2_stage" "default" {
     }
   }
 
-  #  dynamic "default_route_settings" {
-  #    for_each = var.default_stage_access_log_destination_arn != null && var.default_stage_access_log_format != null ? [true] : []
-  #    content {
-  #      data_trace_enabled = var.default_route_data_trace_enabled
-  #      detailed_metrics_enabled         = var.default_route_detailed_metrics_enabled
-  #      logging_level         = var.default_route_logging_level
-  #      throttling_burst_limit         = var.default_route_throttling_burst_limit
-  #      throttling_rate_limit         = var.default_route_throttling_rate_limit
-  #    }
-  #  }
+  dynamic "default_route_settings" {
+    for_each = length(keys(var.default_route_settings)) == 0 ? [] : [var.default_route_settings]
+    content {
+      data_trace_enabled       = lookup(default_route_settings.value, "data_trace_enabled", false)
+      detailed_metrics_enabled = lookup(default_route_settings.value, "detailed_metrics_enabled", false)
+      logging_level            = lookup(default_route_settings.value, "logging_level", "OFF")
+      throttling_burst_limit   = lookup(default_route_settings.value, "throttling_burst_limit", null)
+      throttling_rate_limit    = lookup(default_route_settings.value, "throttling_rate_limit", null)
+    }
+  }
 
   #  # bug - https://github.com/terraform-providers/terraform-provider-aws/issues/12893
   #  dynamic "route_settings" {

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,12 @@ variable "description" {
   default     = null
 }
 
+variable "default_route_settings" {
+  description = "Settings for default route"
+  type        = map(string)
+  default     = null
+}
+
 variable "disable_execute_api_endpoint" {
   description = "Whether clients can invoke the API by using the default execute-api endpoint. To require that clients use a custom domain name to invoke the API, disable the default endpoint"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,7 @@ variable "description" {
 variable "default_route_settings" {
   description = "Settings for default route"
   type        = map(string)
-  default     = null
+  default     = {}
 }
 
 variable "disable_execute_api_endpoint" {


### PR DESCRIPTION
## Description
Add support for default_route_settings, fixes #30.

## Motivation and Context
Control throttling and metrics.

## Breaking Changes
No

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects

Examples updated, also applied on our own real world infra.