### PR TITLE
fix: Fixed output when create_api_domain_name is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ module "api_gateway" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.3.0 |
 
 ## Providers

--- a/outputs.tf
+++ b/outputs.tf
@@ -67,12 +67,12 @@ output "apigatewayv2_domain_name_configuration" {
 
 output "apigatewayv2_domain_name_target_domain_name" {
   description = "The target domain name"
-  value       = var.create && var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "target_domain_name", "") : ""
+  value       = try(aws_apigatewayv2_domain_name.this[0].domain_name_configuration[0].target_domain_name, "")
 }
 
 output "apigatewayv2_domain_name_hosted_zone_id" {
   description = "The Amazon Route 53 Hosted Zone ID of the endpoint"
-  value       = var.create && var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "hosted_zone_id", "") : ""
+  value       = try(aws_apigatewayv2_domain_name.this[0].domain_name_configuration[0].hosted_zone_id, "")
 }
 
 # api mapping

--- a/outputs.tf
+++ b/outputs.tf
@@ -67,12 +67,12 @@ output "apigatewayv2_domain_name_configuration" {
 
 output "apigatewayv2_domain_name_target_domain_name" {
   description = "The target domain name"
-  value       = var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "target_domain_name", "") : ""
+  value       = var.create && var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "target_domain_name", "") : ""
 }
 
 output "apigatewayv2_domain_name_hosted_zone_id" {
   description = "The Amazon Route 53 Hosted Zone ID of the endpoint"
-  value       = var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "hosted_zone_id", "") : ""
+  value       = var.create && var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "hosted_zone_id", "") : ""
 }
 
 # api mapping

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = ">= 3.3.0"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When disabling the entire module by:
* Setting `create = false` 
* Not setting `create_api_domain_name = false`, the outputs cause a plan time error.

Error:
```
Error: Error in function call

  on .terraform/modules/environment.maintenance.this.apigateway.this/outputs.tf line 70, in output "apigatewayv2_domain_name_target_domain_name":
  70:   value       = var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "target_domain_name", "") : ""
    |----------------
    | aws_apigatewayv2_domain_name.this is empty tuple

Call to function "element" failed: cannot read elements from string.

Error: Error in function call

  on .terraform/modules/environment.maintenance.this.apigateway.this/outputs.tf line 75, in output "apigatewayv2_domain_name_hosted_zone_id":
  75:   value       = var.create_api_domain_name ? lookup(tomap(element(element(concat(aws_apigatewayv2_domain_name.this.*.domain_name_configuration, [""]), 0), 0)), "hosted_zone_id", "") : ""
    |----------------
    | aws_apigatewayv2_domain_name.this is empty tuple

Call to function "element" failed: cannot read elements from string.
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We would like to disable the module.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Yes, this is to get it to plan properly.