### PR TITLE
Pass the tls_config argument to the aws_apigatewayv2_integration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,8 @@ resource "aws_apigatewayv2_integration" "this" {
   content_handling_strategy = lookup(each.value, "content_handling_strategy", null)
   credentials_arn           = lookup(each.value, "credentials_arn", null)
   request_parameters        = try(jsondecode(each.value["request_parameters"]), each.value["request_parameters"], null)
+
+  tls_config = lookup(each.value, "tls_config", null)
 }
 
 # VPC Link (Private API)


### PR DESCRIPTION
## Description
Pass the tls_config integration argument to the aws_apigatewayv2_integration resource

## Motivation and Context
Fixes #47.

## Breaking Changes
Shouldn't have any breaking changes

## How Has This Been Tested?
- [] I have tested and validated these changes using one or more of the provided `examples/*` projects

<!--- Please describe in detail how you tested your changes. --> Haven't tested yet

<!--- Include details of your testing environment, and the tests you ran to -->  Haven't tested yet

<!--- see how your change affects other areas of the code, etc. --> Shouldn't affect anything else, but haven't tested yet.
