### PR TITLE
feat: Adds dynamic block to include tls_config if it is present in the integrations input variable

### DIFF
--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -55,6 +55,9 @@ module "api_gateway" {
       lambda_arn             = module.lambda_function.lambda_function_arn
       payload_format_version = "2.0"
       timeout_milliseconds   = 12000
+      tls_config = {
+        server_name_to_verify = local.domain_name
+      }
     }
 
     "GET /some-route" = {

--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,13 @@ resource "aws_apigatewayv2_integration" "this" {
   content_handling_strategy = lookup(each.value, "content_handling_strategy", null)
   credentials_arn           = lookup(each.value, "credentials_arn", null)
   request_parameters        = try(jsondecode(each.value["request_parameters"]), each.value["request_parameters"], null)
+  
+  dynamic "tls_config" {
+    for_each = lookup(each.value, "tls_config", null) == null ? [] : [lookup(each.value, "tls_config", null)]
+    content {
+      server_name_to_verify    = lookup(each.value, "server_name_to_verify", null)
+    }
+  }
 }
 
 # VPC Link (Private API)

--- a/main.tf
+++ b/main.tf
@@ -158,7 +158,7 @@ resource "aws_apigatewayv2_integration" "this" {
   dynamic "tls_config" {
     for_each = lookup(each.value, "tls_config", null) == null ? [] : [lookup(each.value, "tls_config", null)]
     content {
-      server_name_to_verify    = lookup(each.value, "server_name_to_verify", null)
+      server_name_to_verify    = tls_config.value["server_name_to_verify"]
     }
   }
 }


### PR DESCRIPTION
## Description
Custom domain for integration requires us to provide [tls_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_integration#tls_config) for the integration, which API Gateway uses to verify the hostname on the integration's certificate. It was not possible to include this configuration in this module, and this change would allow us to pass this configuration within the integrations variable.

## Motivation and Context
Earlier, there was no option to include tls_config configuration for the API gateway integrations using this module. I have now added a dynamic block to include this configuration if it is present in the integrations input variable. Fixes #47.

## Breaking Changes
There are no breaking changes included.

## How Has This Been Tested?
- I have updated the example at `examples/complete-http` and tested the changes. 
- I have also tested and validated these changes within our infrastructure code, confirmed it to be working as expected.
