### PR TITLE
chore: updates to support websocket API Gateway

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ module "api_gateway" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.57.0 |
 
 ## Modules
 
@@ -123,6 +123,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_api_key_selection_expression"></a> [api\_key\_selection\_expression](#input\_api\_key\_selection\_expression) | An API key selection expression. Valid values: $context.authorizer.usageIdentifierKey, $request.header.x-api-key. | `string` | `"$request.header.x-api-key"` | no |
+| <a name="input_api_mapping_key"></a> [api\_mapping\_key](#input\_api\_mapping\_key) | The [API mapping key](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-mapping-template-reference.html) | `string` | `null` | no |
 | <a name="input_api_version"></a> [api\_version](#input\_api\_version) | A version identifier for the API | `string` | `null` | no |
 | <a name="input_body"></a> [body](#input\_body) | An OpenAPI specification that defines the set of routes and integrations to create as part of the HTTP APIs. Supported only for HTTP APIs. | `string` | `null` | no |
 | <a name="input_cors_configuration"></a> [cors\_configuration](#input\_cors\_configuration) | The cross-origin resource sharing (CORS) configuration. Applicable for HTTP APIs. | `any` | `{}` | no |
@@ -143,6 +144,7 @@ No modules.
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name to use for API gateway | `string` | `null` | no |
 | <a name="input_domain_name_certificate_arn"></a> [domain\_name\_certificate\_arn](#input\_domain\_name\_certificate\_arn) | The ARN of an AWS-managed certificate that will be used by the endpoint for the domain name | `string` | `null` | no |
 | <a name="input_domain_name_tags"></a> [domain\_name\_tags](#input\_domain\_name\_tags) | A mapping of tags to assign to API domain name resource. | `map(string)` | `{}` | no |
+| <a name="input_fail_on_warnings"></a> [fail\_on\_warnings](#input\_fail\_on\_warnings) | Whether warnings should return an error while API Gateway is creating or updating the resource using an OpenAPI specification | `bool` | `null` | no |
 | <a name="input_integrations"></a> [integrations](#input\_integrations) | Map of API gateway routes with integrations | `map(any)` | `{}` | no |
 | <a name="input_mutual_tls_authentication"></a> [mutual\_tls\_authentication](#input\_mutual\_tls\_authentication) | An Amazon S3 URL that specifies the truststore for mutual TLS authentication as well as version, keyed at uri and version | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the API | `string` | `""` | no |
@@ -162,13 +164,14 @@ No modules.
 | <a name="output_apigatewayv2_api_arn"></a> [apigatewayv2\_api\_arn](#output\_apigatewayv2\_api\_arn) | The ARN of the API |
 | <a name="output_apigatewayv2_api_execution_arn"></a> [apigatewayv2\_api\_execution\_arn](#output\_apigatewayv2\_api\_execution\_arn) | The ARN prefix to be used in an aws\_lambda\_permission's source\_arn attribute or in an aws\_iam\_policy to authorize access to the @connections API. |
 | <a name="output_apigatewayv2_api_id"></a> [apigatewayv2\_api\_id](#output\_apigatewayv2\_api\_id) | The API identifier |
-| <a name="output_apigatewayv2_api_mapping_id"></a> [apigatewayv2\_api\_mapping\_id](#output\_apigatewayv2\_api\_mapping\_id) | The API mapping identifier. |
+| <a name="output_apigatewayv2_api_mapping_id"></a> [apigatewayv2\_api\_mapping\_id](#output\_apigatewayv2\_api\_mapping\_id) | The API mapping identifier |
 | <a name="output_apigatewayv2_domain_name_api_mapping_selection_expression"></a> [apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression](#output\_apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression) | The API mapping selection expression for the domain name |
 | <a name="output_apigatewayv2_domain_name_arn"></a> [apigatewayv2\_domain\_name\_arn](#output\_apigatewayv2\_domain\_name\_arn) | The ARN of the domain name |
 | <a name="output_apigatewayv2_domain_name_configuration"></a> [apigatewayv2\_domain\_name\_configuration](#output\_apigatewayv2\_domain\_name\_configuration) | The domain name configuration |
 | <a name="output_apigatewayv2_domain_name_hosted_zone_id"></a> [apigatewayv2\_domain\_name\_hosted\_zone\_id](#output\_apigatewayv2\_domain\_name\_hosted\_zone\_id) | The Amazon Route 53 Hosted Zone ID of the endpoint |
 | <a name="output_apigatewayv2_domain_name_id"></a> [apigatewayv2\_domain\_name\_id](#output\_apigatewayv2\_domain\_name\_id) | The domain name identifier |
 | <a name="output_apigatewayv2_domain_name_target_domain_name"></a> [apigatewayv2\_domain\_name\_target\_domain\_name](#output\_apigatewayv2\_domain\_name\_target\_domain\_name) | The target domain name |
+| <a name="output_apigatewayv2_route"></a> [apigatewayv2\_route](#output\_apigatewayv2\_route) | Map containing the routes created and their attributes |
 | <a name="output_apigatewayv2_vpc_link_arn"></a> [apigatewayv2\_vpc\_link\_arn](#output\_apigatewayv2\_vpc\_link\_arn) | The map of VPC Link ARNs |
 | <a name="output_apigatewayv2_vpc_link_id"></a> [apigatewayv2\_vpc\_link\_id](#output\_apigatewayv2\_vpc\_link\_id) | The map of VPC Link identifiers |
 | <a name="output_default_apigatewayv2_stage_arn"></a> [default\_apigatewayv2\_stage\_arn](#output\_default\_apigatewayv2\_stage\_arn) | The default stage ARN |

--- a/examples/complete-http/README.md
+++ b/examples/complete-http/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.59 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.1 |
@@ -30,17 +30,17 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.59 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.57.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 3.0 |
-| <a name="module_api_gateway"></a> [api\_gateway](#module\_api\_gateway) | ../../ |  |
+| <a name="module_api_gateway"></a> [api\_gateway](#module\_api\_gateway) | ../../ | n/a |
 | <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 2.0 |
 | <a name="module_step_function"></a> [step\_function](#module\_step\_function) | terraform-aws-modules/step-functions/aws | ~> 2.0 |
 
@@ -62,7 +62,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Custom domain name to use on API Gateway endpoint | `string` | n/a | yes |
 
 ## Outputs
 
@@ -74,6 +76,7 @@ No inputs.
 | <a name="output_apigatewayv2_domain_name_configuration"></a> [apigatewayv2\_domain\_name\_configuration](#output\_apigatewayv2\_domain\_name\_configuration) | The domain name configuration |
 | <a name="output_apigatewayv2_domain_name_id"></a> [apigatewayv2\_domain\_name\_id](#output\_apigatewayv2\_domain\_name\_id) | The domain name identifier |
 | <a name="output_apigatewayv2_hosted_zone_id"></a> [apigatewayv2\_hosted\_zone\_id](#output\_apigatewayv2\_hosted\_zone\_id) | The Amazon Route 53 Hosted Zone ID of the endpoint |
+| <a name="output_apigatewayv2_route"></a> [apigatewayv2\_route](#output\_apigatewayv2\_route) | Map containing the routes created and their attributes |
 | <a name="output_apigatewayv2_target_domain_name"></a> [apigatewayv2\_target\_domain\_name](#output\_apigatewayv2\_target\_domain\_name) | The target domain name |
 | <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
 | <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | The ARN of the Lambda Function |

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -12,8 +12,7 @@ provider "aws" {
 }
 
 locals {
-  domain_name = "terraform-aws-modules.modules.tf" # trimsuffix(data.aws_route53_zone.this.name, ".")
-  subdomain   = "complete-http"
+  subdomain = "complete-http"
 }
 
 ###################
@@ -38,7 +37,7 @@ module "api_gateway" {
     truststore_version = aws_s3_bucket_object.truststore.version_id
   }
 
-  domain_name                 = local.domain_name
+  domain_name                 = var.domain_name
   domain_name_certificate_arn = module.acm.acm_certificate_arn
 
   default_stage_access_log_destination_arn = aws_cloudwatch_log_group.logs.arn
@@ -82,7 +81,7 @@ module "api_gateway" {
     "$default" = {
       lambda_arn = module.lambda_function.lambda_function_arn
       tls_config = jsonencode({
-        server_name_to_verify = local.domain_name
+        server_name_to_verify = var.domain_name
       })
     }
 
@@ -102,16 +101,16 @@ module "api_gateway" {
 ######
 
 data "aws_route53_zone" "this" {
-  name = local.domain_name
+  name = var.domain_name
 }
 
 module "acm" {
   source  = "terraform-aws-modules/acm/aws"
   version = "~> 3.0"
 
-  domain_name               = local.domain_name
+  domain_name               = var.domain_name
   zone_id                   = data.aws_route53_zone.this.id
-  subject_alternative_names = ["${local.subdomain}.${local.domain_name}"]
+  subject_alternative_names = ["${local.subdomain}.${var.domain_name}"]
 }
 
 ##########

--- a/examples/complete-http/outputs.tf
+++ b/examples/complete-http/outputs.tf
@@ -125,6 +125,11 @@ output "apigatewayv2_hosted_zone_id" {
   value       = module.api_gateway.apigatewayv2_domain_name_hosted_zone_id
 }
 
+output "apigatewayv2_route" {
+  description = "Map containing the routes created and their attributes"
+  value       = module.api_gateway.apigatewayv2_route
+}
+
 # Route53 record
 output "api_fqdn" {
   description = "List of Route53 records"

--- a/examples/complete-http/terraform.tfvars.example
+++ b/examples/complete-http/terraform.tfvars.example
@@ -1,0 +1,1 @@
+domain_name="yourdomain.com"

--- a/examples/complete-http/variables.tf
+++ b/examples/complete-http/variables.tf
@@ -1,0 +1,4 @@
+variable "domain_name" {
+  description = "Custom domain name to use on API Gateway endpoint"
+  type        = string
+}

--- a/examples/complete-http/versions.tf
+++ b/examples/complete-http/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 2.59"
+    aws    = ">= 3.35"
     random = ">= 2.0"
     null   = ">= 2.0"
     tls    = ">= 3.1"

--- a/examples/vpc-link-http/README.md
+++ b/examples/vpc-link-http/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.59 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
@@ -29,8 +29,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 
@@ -38,7 +38,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_alb"></a> [alb](#module\_alb) | terraform-aws-modules/alb/aws | ~> 6.0 |
 | <a name="module_alb_security_group"></a> [alb\_security\_group](#module\_alb\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
-| <a name="module_api_gateway"></a> [api\_gateway](#module\_api\_gateway) | ../../ |  |
+| <a name="module_api_gateway"></a> [api\_gateway](#module\_api\_gateway) | ../../ | n/a |
 | <a name="module_api_gateway_security_group"></a> [api\_gateway\_security\_group](#module\_api\_gateway\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 2.0 |
 | <a name="module_lambda_security_group"></a> [lambda\_security\_group](#module\_lambda\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |

--- a/examples/vpc-link-http/versions.tf
+++ b/examples/vpc-link-http/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 2.59"
+    aws    = ">= 3.35"
     random = ">= 2.0"
     null   = ">= 2.0"
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -77,15 +77,15 @@ output "apigatewayv2_domain_name_hosted_zone_id" {
 
 # api mapping
 output "apigatewayv2_api_mapping_id" {
-  description = "The API mapping identifier."
+  description = "The API mapping identifier"
   value       = element(concat(aws_apigatewayv2_api_mapping.this.*.id, [""]), 0)
 }
 
 # route
-# output "apigatewayv2_route_id" {
-#  description = "The default route identifier."
-#  value       = element(concat(aws_apigatewayv2_route.this.*.id, [""]), 0)
-# }
+output "apigatewayv2_route" {
+  description = "Map containing the routes created and their attributes"
+  value       = aws_apigatewayv2_route.this
+}
 
 # VPC link
 output "apigatewayv2_vpc_link_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -131,6 +131,12 @@ variable "api_version" {
   default     = null
 }
 
+variable "fail_on_warnings" {
+  description = "Whether warnings should return an error while API Gateway is creating or updating the resource using an OpenAPI specification"
+  type        = bool
+  default     = null
+}
+
 variable "tags" {
   description = "A mapping of tags to assign to API gateway resources."
   type        = map(string)
@@ -158,7 +164,12 @@ variable "default_stage_tags" {
 }
 
 #####
-# default stage API mapping
+# API mapping
+variable "api_mapping_key" {
+  description = "The [API mapping key](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-mapping-template-reference.html)"
+  type        = string
+  default     = null
+}
 
 ####
 # domain name

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.3.0"
+    aws = ">= 3.35"
   }
 }


### PR DESCRIPTION
## Description
- bump min version of Terraform supported to 0.13.1
- bump min version of AWS provider supported to 3.35 for `request_parameter` support (websocket)
- update example to use tfvars/variable for testing with users own domain
- add output for routes which have a map of maps input - so all route resources and their attributes are lazily exported
- add conditional check blocks for if target type is `HTTP` or `WEBSOCKET`
- re-enable `route_settings`
- add `fail_on_warnings` attribute to `aws_apigatewayv2_api`
- add a `depends_on` on `aws_apigatewayv2_route` so that example deployes in one apply successfully
- add `api_mapping_key` to API mapping resource (websocket)
- add `authorization_scopes`, `request_models`, and `request_parameter` attributes to `aws_apigatewayv2_route`

## Motivation and Context
- updates for websocket support - will have a PR showing websocket example coming soon

## Breaking Changes
- maybe; Terraform 0.12 support is dropped

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- tested using `complete-http` example
