### PR TITLE
Feat: Add create_before_destroy lifecycle to integration resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -161,6 +161,10 @@ resource "aws_apigatewayv2_integration" "this" {
       server_name_to_verify = tls_config.value["server_name_to_verify"]
     }
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # VPC Link (Private API)


### PR DESCRIPTION
## Description
This change adds a lifecycle policy to the aws_apigatewayv2_integration to allow for more stable changes to existing resources.

## Motivation and Context
If there is a terraform change replacing both an API Gateway Route and an API Gateway Integration, it can run into an issue where a VPC link is being destroyed as the old Gateway Route is being deleted. The error becomes:
`Cannot delete Integration because it is referenced by the following Routes with Ids:`

In the [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment) for aws api_gateway_deployment, it suggests to use a lifecycle block to create_before_destroy, allowing for the VPC link to be connected to the new API Gateway Route before destroying the connection. This also prevents downtime between moving the link.


## How Has This Been Tested?
- [x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
I tested using the examples/vpc-link-http. 
I also used this branch in my own repository to test it fixed the bug.
