### PR TITLE
Support authorization_scopes and request_models on routes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,9 +129,8 @@ resource "aws_apigatewayv2_route" "this" {
   route_response_selection_expression = lookup(each.value, "route_response_selection_expression", null)
   target                              = "integrations/${aws_apigatewayv2_integration.this[each.key].id}"
 
-  # Not sure what structure is allowed for these arguments...
-  #  authorization_scopes = lookup(each.value, "authorization_scopes", null)
-  #  request_models  = lookup(each.value, "request_models", null)
+  authorization_scopes = try(jsondecode(each.value["authorization_scopes"]), each.value["authorization_scopes"], null)
+  request_models       = try(jsondecode(each.value["request_models"]), each.value["request_models"], null)
 }
 
 resource "aws_apigatewayv2_integration" "this" {


### PR DESCRIPTION
## Description

Set `authorization_scopes` and `request_models` on the created route resource when specified in `integrations`.

## Motivation and Context

I'm experimenting with converting a toy SAM template to Terraform using this module, and found that i couldn't proceed because the module doesn't handle `authorization_scopes`.

Both this attribute and `request_models` are commented out in the source because the previous dev didn't know what their structure was. Per the [provider source](https://github.com/hashicorp/terraform-provider-aws/blob/b8b7fee0e5cf4b469d8d4d2a2dc01ed13654a03a/aws/resource_aws_apigatewayv2_route.go#L24), `authorization_scopes` is a `set(string)` and `request_models` is a `map(string)`.

I'm not sure it really matters, though, since `integrations` is a `map(any)` — if i understand correctly, that requires you to use `jsonencode()` or similar on non-scalar values. That's how some of the integration resource's attributes [are currently handled](https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/blob/333ca34c6459ac545aa86c21b9df2786db044d2f/main.tf#L156), anyway.

I think the `try()` method being used here would allow `integrations` to be changed to a fully typed `map(object(...))` whilst retaining backwards compatibility, but i haven't tried making that change myself. (I'm not familiar enough with Terraform or this project to know if it's even desirable.)

## Breaking Changes

This shouldn't affect backwards compatibility.

## How Has This Been Tested?

- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

I tested this by sourcing my branch of the repo as a local module, adding an integration like the following, and deploying to AWS.

```
integrations = {
  "GET /hello" = {
    lambda_arn             = module.hello_world_function.lambda_function_arn
    payload_format_version = "2.0"
    authorization_type     = "JWT"
    authorizer_id          = aws_apigatewayv2_authorizer.my_authorizer.id
    authorization_scopes   = jsonencode(["my_scope"])
  }
}
```

This resulted in the route being associated with the authoriser and having the correct authorisation scopes specified.

If there's further testing i should do, please let me know how; i'm still pretty new to both Terraform and AWS.