### PR TITLE
feat: Add support for response_parameters in integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ module "api_gateway" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.24.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.24.0 |
 
 ## Modules
 

--- a/examples/complete-http/README.md
+++ b/examples/complete-http/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.59 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.24.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.1 |
@@ -30,7 +30,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.59 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.24.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.1 |
@@ -40,7 +40,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 3.0 |
-| <a name="module_api_gateway"></a> [api\_gateway](#module\_api\_gateway) | ../../ |  |
+| <a name="module_api_gateway"></a> [api\_gateway](#module\_api\_gateway) | ../../ | n/a |
 | <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 2.0 |
 | <a name="module_step_function"></a> [step\_function](#module\_step\_function) | terraform-aws-modules/step-functions/aws | ~> 2.0 |
 

--- a/examples/complete-http/README.md
+++ b/examples/complete-http/README.md
@@ -40,7 +40,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 3.0 |
-| <a name="module_api_gateway"></a> [api\_gateway](#module\_api\_gateway) | ../../ | n/a |
+| <a name="module_api_gateway"></a> [api\_gateway](#module\_api\_gateway) | ../../ |  |
 | <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 2.0 |
 | <a name="module_step_function"></a> [step\_function](#module\_step\_function) | terraform-aws-modules/step-functions/aws | ~> 2.0 |
 

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -84,6 +84,22 @@ module "api_gateway" {
       tls_config = jsonencode({
         server_name_to_verify = local.domain_name
       })
+
+      response_parameters = jsonencode([
+        {
+          status_code = 500
+          mappings = {
+            "append:header.header1" = "$context.requestId"
+            "overwrite:statuscode"  = "403"
+          }
+        },
+        {
+          status_code = 404
+          mappings = {
+            "append:header.error" = "$stageVariables.environmentId"
+          }
+        }
+      ])
     }
 
   }

--- a/examples/complete-http/versions.tf
+++ b/examples/complete-http/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 2.59"
+    aws    = ">= 3.24.0"
     random = ">= 2.0"
     null   = ">= 2.0"
     tls    = ">= 3.1"

--- a/examples/complete-http/versions.tf
+++ b/examples/complete-http/versions.tf
@@ -2,9 +2,21 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.24.0"
-    random = ">= 2.0"
-    null   = ">= 2.0"
-    tls    = ">= 3.1"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.24.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.1"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -162,6 +162,14 @@ resource "aws_apigatewayv2_integration" "this" {
     }
   }
 
+  dynamic "response_parameters" {
+    for_each = flatten([try(jsondecode(each.value["response_parameters"]), each.value["response_parameters"], [])])
+    content {
+      status_code = response_parameters.value["status_code"]
+      mappings    = response_parameters.value["mappings"]
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.24.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.24.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.3.0"
+    aws = ">= 3.24.0"
   }
 }


### PR DESCRIPTION
## Description
Add support for "response_parameters" to an integration to allow modification of response headers.

## Motivation and Context
It is not possible to set the "response_parameters" block on an integration using this module, which can be useful for setting security headers that get added to all API responses.

## Breaking Changes
There are no breaking changes

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects