### PR TITLE
Add support for authorizer provisioning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,8 @@ resource "aws_apigatewayv2_authorizer" "this" {
   authorizer_uri                    = lookup(each.value, "authorizer_uri", null)
   identity_sources                  = lookup(each.value, "identity_sources", ["route.request.header.Auth"])
   authorizer_payload_format_version = lookup(each.value, "authorizer_payload_format_version", lookup(each.value, "authorizer_type", "REQUEST") == "REQUEST" ? "2.0" : null)
+  authorizer_credentials_arn        = lookup(each.value, "authorizer_credentials_arn", null)
+  enable_simple_responses           = lookup(each.value, "enable_simple_responses", var.protocol_type == "HTTP" ? true : null)
 }
 
 # Routes and integrations

--- a/outputs.tf
+++ b/outputs.tf
@@ -97,3 +97,8 @@ output "apigatewayv2_vpc_link_arn" {
   description = "The map of VPC Link ARNs"
   value       = { for k, v in aws_apigatewayv2_vpc_link.this : k => v.arn }
 }
+
+output "apigatewayv2_authorizer_id" {
+  description = "The map of Authorizer IDs"
+  value       = { for k, v in aws_apigatewayv2_authorizer.this : k => v.id }
+}


### PR DESCRIPTION
## Description

provision authorizer when `authorizer_type` is set to CUSTOM

## Motivation and Context

In cases when CUSTOM authorizer have to be used `authorizer_id` is not available until api-gateway is created, so it causes a chicken-egg problem.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
