### PR TITLE
fix: Add support for passing authorization_scopes on routes with JWT authorizer

### DIFF
--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -81,6 +81,20 @@ module "api_gateway" {
       authorizer_key         = "cognito"
     }
 
+    "GET /some-route-with-authorizer-and-scope" = {
+      lambda_arn             = module.lambda_function.lambda_function_arn
+      payload_format_version = "2.0"
+      authorizer_key         = "cognito"
+      authorization_scopes   = ["tf/something.relevant.read"] # Should comply with the resource server configuration part of the cognito user pool
+    }
+
+    "GET /some-route-with-authorizer-and-different-scope" = {
+      lambda_arn             = module.lambda_function.lambda_function_arn
+      payload_format_version = "2.0"
+      authorizer_key         = "cognito"
+      authorization_scopes   = ["tf/something.relevant.write"] # Should comply with the resource server configuration part of the cognito user pool
+    }
+
     "POST /start-step-function" = {
       integration_type    = "AWS_PROXY"
       integration_subtype = "StepFunctions-StartExecution"

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -85,14 +85,14 @@ module "api_gateway" {
       lambda_arn             = module.lambda_function.lambda_function_arn
       payload_format_version = "2.0"
       authorizer_key         = "cognito"
-      authorization_scopes   = ["tf/something.relevant.read"] # Should comply with the resource server configuration part of the cognito user pool
+      authorization_scopes   = "tf/something.relevant.read,tf/something.relevant.write" # Should comply with the resource server configuration part of the cognito user pool
     }
 
     "GET /some-route-with-authorizer-and-different-scope" = {
       lambda_arn             = module.lambda_function.lambda_function_arn
       payload_format_version = "2.0"
       authorizer_key         = "cognito"
-      authorization_scopes   = ["tf/something.relevant.write"] # Should comply with the resource server configuration part of the cognito user pool
+      authorization_scopes   = "tf/something.relevant.write" # Should comply with the resource server configuration part of the cognito user pool
     }
 
     "POST /start-step-function" = {

--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ resource "aws_apigatewayv2_route" "this" {
   route_key = each.key
 
   api_key_required                    = try(each.value.api_key_required, null)
-  authorization_scopes                = try(each.value.authorization_scopes, null)
+  authorization_scopes                = try(split(",",each.value.authorization_scopes), null)
   authorization_type                  = try(each.value.authorization_type, "NONE")
   authorizer_id                       = try(aws_apigatewayv2_authorizer.this[each.value.authorizer_key].id, each.value.authorizer_id, null)
   model_selection_expression          = try(each.value.model_selection_expression, null)

--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ resource "aws_apigatewayv2_route" "this" {
   route_key = each.key
 
   api_key_required                    = try(each.value.api_key_required, null)
-  authorization_scopes                = try(split(",",each.value.authorization_scopes), null)
+  authorization_scopes                = try(split(",", each.value.authorization_scopes), null)
   authorization_type                  = try(each.value.authorization_type, "NONE")
   authorizer_id                       = try(aws_apigatewayv2_authorizer.this[each.value.authorizer_key].id, each.value.authorizer_id, null)
   model_selection_expression          = try(each.value.model_selection_expression, null)

--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,7 @@ resource "aws_apigatewayv2_route" "this" {
   route_key = each.key
 
   api_key_required                    = try(each.value.api_key_required, null)
+  authorization_scopes                = try(each.value.authorization_scopes, null)
   authorization_type                  = try(each.value.authorization_type, "NONE")
   authorizer_id                       = try(aws_apigatewayv2_authorizer.this[each.value.authorizer_key].id, each.value.authorizer_id, null)
   model_selection_expression          = try(each.value.model_selection_expression, null)
@@ -132,9 +133,8 @@ resource "aws_apigatewayv2_route" "this" {
   route_response_selection_expression = try(each.value.route_response_selection_expression, null)
   target                              = "integrations/${aws_apigatewayv2_integration.this[each.key].id}"
 
-  # Not sure what structure is allowed for these arguments...
-  #  authorization_scopes = try(each.value.authorization_scopes, null)
-  #  request_models  = try(each.value.request_models, null)
+  # Have been added to the docs. But is WEBSOCKET only(not yet supported)
+  # request_models  = try(each.value.request_models, null)
 }
 
 resource "aws_apigatewayv2_integration" "this" {


### PR DESCRIPTION
## Description
Make it possible to pass the authorization_scopes as a comma separated string on the integration level. Passing it as a set of string like the AWS resource expects makes the variable validation fail with a " attribute types must all match for conversion to map" as also described [here](https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/issues/61) 

## Motivation and Context
Due to missing documentation on the AWS provider the authorization_scopes parameter was being ignored. The docs have been updated as seen [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_route)
This fixes [issue](https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/issues/66)

## Breaking Changes
No. This is an optional parameter

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
