### PR TITLE
feat: Added support for ttl in authorizer resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -191,6 +191,7 @@ resource "aws_apigatewayv2_authorizer" "this" {
   name                              = try(each.value.name, null)
   authorizer_uri                    = try(each.value.authorizer_uri, null)
   authorizer_payload_format_version = try(each.value.authorizer_payload_format_version, null)
+  authorizer_result_ttl_in_seconds  = try(each.value.authorizer_result_ttl_in_seconds, 300)
 
   dynamic "jwt_configuration" {
     for_each = length(try(each.value.audience, [each.value.issuer], [])) > 0 ? [true] : []

--- a/main.tf
+++ b/main.tf
@@ -191,7 +191,7 @@ resource "aws_apigatewayv2_authorizer" "this" {
   name                              = try(each.value.name, null)
   authorizer_uri                    = try(each.value.authorizer_uri, null)
   authorizer_payload_format_version = try(each.value.authorizer_payload_format_version, null)
-  authorizer_result_ttl_in_seconds  = try(each.value.authorizer_result_ttl_in_seconds, 300)
+  authorizer_result_ttl_in_seconds  = try(each.value.authorizer_result_ttl_in_seconds, null)
 
   dynamic "jwt_configuration" {
     for_each = length(try(each.value.audience, [each.value.issuer], [])) > 0 ? [true] : []


### PR DESCRIPTION
## Description
Add compatibility for authorizer_result_ttl_in_seconds option in aws_apigatewayv2_authorizer resource

## Motivation and Context
Support for specifying ttl on authorisers was missing

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [x] I have executed `pre-commit run -a` on my pull request
