### PR TITLE
feat: Added enable_simple_responses and authorizer_credentials_arn to authorizers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.72.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/main.tf
+++ b/main.tf
@@ -192,6 +192,7 @@ resource "aws_apigatewayv2_authorizer" "this" {
   authorizer_uri                    = try(each.value.authorizer_uri, null)
   authorizer_payload_format_version = try(each.value.authorizer_payload_format_version, null)
   authorizer_result_ttl_in_seconds  = try(each.value.authorizer_result_ttl_in_seconds, null)
+  enable_simple_responses           = try(each.value.enable_simple_responses, false)
 
   dynamic "jwt_configuration" {
     for_each = length(try(each.value.audience, [each.value.issuer], [])) > 0 ? [true] : []

--- a/main.tf
+++ b/main.tf
@@ -192,7 +192,8 @@ resource "aws_apigatewayv2_authorizer" "this" {
   authorizer_uri                    = try(each.value.authorizer_uri, null)
   authorizer_payload_format_version = try(each.value.authorizer_payload_format_version, null)
   authorizer_result_ttl_in_seconds  = try(each.value.authorizer_result_ttl_in_seconds, null)
-  enable_simple_responses           = try(each.value.enable_simple_responses, false)
+  authorizer_credentials_arn        = try(each.value.authorizer_credentials_arn, null)
+  enable_simple_responses           = try(each.value.enable_simple_responses, null)
 
   dynamic "jwt_configuration" {
     for_each = length(try(each.value.audience, [each.value.issuer], [])) > 0 ? [true] : []


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add the ability to pass `enable_simple_responses` and `authorizer_credentials_arn` to an `aws_apigatewayv2_authorizer`

Fixes #70

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Matches functionality in underlying aws resource - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_authorizer#enable_simple_responses

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->