### PR TITLE
feat: Added API GW Authorizer IDs to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ No modules.
 | <a name="output_apigatewayv2_api_execution_arn"></a> [apigatewayv2\_api\_execution\_arn](#output\_apigatewayv2\_api\_execution\_arn) | The ARN prefix to be used in an aws\_lambda\_permission's source\_arn attribute or in an aws\_iam\_policy to authorize access to the @connections API. |
 | <a name="output_apigatewayv2_api_id"></a> [apigatewayv2\_api\_id](#output\_apigatewayv2\_api\_id) | The API identifier |
 | <a name="output_apigatewayv2_api_mapping_id"></a> [apigatewayv2\_api\_mapping\_id](#output\_apigatewayv2\_api\_mapping\_id) | The API mapping identifier. |
+| <a name="output_apigatewayv2_authorizer_id"></a> [apigatewayv2\_authorizer\_id](#output\_apigatewayv2\_authorizer\_id) | The map of API Gateway Authorizer identifiers |
 | <a name="output_apigatewayv2_domain_name_api_mapping_selection_expression"></a> [apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression](#output\_apigatewayv2\_domain\_name\_api\_mapping\_selection\_expression) | The API mapping selection expression for the domain name |
 | <a name="output_apigatewayv2_domain_name_arn"></a> [apigatewayv2\_domain\_name\_arn](#output\_apigatewayv2\_domain\_name\_arn) | The ARN of the domain name |
 | <a name="output_apigatewayv2_domain_name_configuration"></a> [apigatewayv2\_domain\_name\_configuration](#output\_apigatewayv2\_domain\_name\_configuration) | The domain name configuration |

--- a/examples/complete-http/README.md
+++ b/examples/complete-http/README.md
@@ -75,6 +75,7 @@ No inputs.
 | <a name="output_apigatewayv2_domain_name_id"></a> [apigatewayv2\_domain\_name\_id](#output\_apigatewayv2\_domain\_name\_id) | The domain name identifier |
 | <a name="output_apigatewayv2_hosted_zone_id"></a> [apigatewayv2\_hosted\_zone\_id](#output\_apigatewayv2\_hosted\_zone\_id) | The Amazon Route 53 Hosted Zone ID of the endpoint |
 | <a name="output_apigatewayv2_target_domain_name"></a> [apigatewayv2\_target\_domain\_name](#output\_apigatewayv2\_target\_domain\_name) | The target domain name |
+| <a name="output_authorizer_id"></a> [authorizer\_id](#output\_authorizer\_id) | API Gateway Authorizer ID |
 | <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
 | <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | The ARN of the Lambda Function |
 | <a name="output_lambda_function_invoke_arn"></a> [lambda\_function\_invoke\_arn](#output\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |

--- a/examples/complete-http/README.md
+++ b/examples/complete-http/README.md
@@ -71,11 +71,11 @@ No inputs.
 | <a name="output_api_endpoint"></a> [api\_endpoint](#output\_api\_endpoint) | FQDN of an API endpoint |
 | <a name="output_api_fqdn"></a> [api\_fqdn](#output\_api\_fqdn) | List of Route53 records |
 | <a name="output_apigatewayv2_api_api_endpoint"></a> [apigatewayv2\_api\_api\_endpoint](#output\_apigatewayv2\_api\_api\_endpoint) | The URI of the API |
+| <a name="output_apigatewayv2_authorizer_id"></a> [apigatewayv2\_authorizer\_id](#output\_apigatewayv2\_authorizer\_id) | The map of API Gateway Authorizer identifiers |
 | <a name="output_apigatewayv2_domain_name_configuration"></a> [apigatewayv2\_domain\_name\_configuration](#output\_apigatewayv2\_domain\_name\_configuration) | The domain name configuration |
 | <a name="output_apigatewayv2_domain_name_id"></a> [apigatewayv2\_domain\_name\_id](#output\_apigatewayv2\_domain\_name\_id) | The domain name identifier |
 | <a name="output_apigatewayv2_hosted_zone_id"></a> [apigatewayv2\_hosted\_zone\_id](#output\_apigatewayv2\_hosted\_zone\_id) | The Amazon Route 53 Hosted Zone ID of the endpoint |
 | <a name="output_apigatewayv2_target_domain_name"></a> [apigatewayv2\_target\_domain\_name](#output\_apigatewayv2\_target\_domain\_name) | The target domain name |
-| <a name="output_authorizer_id"></a> [authorizer\_id](#output\_authorizer\_id) | API Gateway Authorizer ID |
 | <a name="output_lambda_cloudwatch_log_group_arn"></a> [lambda\_cloudwatch\_log\_group\_arn](#output\_lambda\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch Log Group |
 | <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | The ARN of the Lambda Function |
 | <a name="output_lambda_function_invoke_arn"></a> [lambda\_function\_invoke\_arn](#output\_lambda\_function\_invoke\_arn) | The Invoke ARN of the Lambda Function |

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -304,7 +304,6 @@ resource "tls_private_key" "private_key" {
 }
 
 resource "tls_self_signed_cert" "example" {
-  key_algorithm     = tls_private_key.private_key.algorithm
   is_ca_certificate = true
   private_key_pem   = tls_private_key.private_key.private_key_pem
 

--- a/examples/complete-http/outputs.tf
+++ b/examples/complete-http/outputs.tf
@@ -135,3 +135,8 @@ output "api_endpoint" {
   description = "FQDN of an API endpoint"
   value       = "https://${aws_route53_record.api.fqdn}"
 }
+
+output "authorizer_id" {
+  description = "API Gateway Authorizer ID"
+  value       = lookup(module.api_gateway.apigatewayv2_authorizer_id, "cognito")
+}

--- a/examples/complete-http/outputs.tf
+++ b/examples/complete-http/outputs.tf
@@ -136,7 +136,7 @@ output "api_endpoint" {
   value       = "https://${aws_route53_record.api.fqdn}"
 }
 
-output "authorizer_id" {
-  description = "API Gateway Authorizer ID"
-  value       = lookup(module.api_gateway.apigatewayv2_authorizer_id, "cognito")
+output "apigatewayv2_authorizer_id" {
+  description = "The map of API Gateway Authorizer identifiers"
+  value       = module.api_gateway.apigatewayv2_authorizer_id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -97,3 +97,8 @@ output "apigatewayv2_vpc_link_arn" {
   description = "The map of VPC Link ARNs"
   value       = { for k, v in aws_apigatewayv2_vpc_link.this : k => v.arn }
 }
+
+output "apigatewayv2_authorizer_id" {
+  description = "The map of API Gateway Authorizer identifiers"
+  value       = { for k, v in aws_apigatewayv2_authorizer.this : k => v.id }
+}


### PR DESCRIPTION
## Description
Added map of created API Gateway Authorisers to module outputs.

## Motivation and Context
Required for referencing authorisers outside of module usage, as no provider data resource exists

## Breaking Changes
None

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
