### PR TITLE
feat: Enable route_settings in default stage

### DIFF
--- a/examples/complete-http/README.md
+++ b/examples/complete-http/README.md
@@ -41,7 +41,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 3.0 |
 | <a name="module_api_gateway"></a> [api\_gateway](#module\_api\_gateway) | ../../ | n/a |
-| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 2.0 |
+| <a name="module_lambda_function"></a> [lambda\_function](#module\_lambda\_function) | terraform-aws-modules/lambda/aws | ~> 3.0 |
 | <a name="module_step_function"></a> [step\_function](#module\_step\_function) | terraform-aws-modules/step-functions/aws | ~> 2.0 |
 
 ## Resources
@@ -53,7 +53,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_cognito_user_pool.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) | resource |
 | [aws_route53_record.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_s3_bucket.truststore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_object.truststore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_object.truststore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [tls_private_key.private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -73,6 +73,8 @@ module "api_gateway" {
       payload_format_version = "2.0"
       authorization_type     = "JWT"
       authorizer_id          = aws_apigatewayv2_authorizer.some_authorizer.id
+      throttling_rate_limit  = 80
+      throttling_burst_limit = 40
     }
 
     "GET /some-route-with-authorizer" = {

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -86,6 +86,7 @@ module "api_gateway" {
     "GET /some-route-with-authorizer-and-scope" = {
       lambda_arn             = module.lambda_function.lambda_function_arn
       payload_format_version = "2.0"
+      authorization_type     = "JWT"
       authorizer_key         = "cognito"
       authorization_scopes   = "tf/something.relevant.read,tf/something.relevant.write" # Should comply with the resource server configuration part of the cognito user pool
     }
@@ -93,6 +94,7 @@ module "api_gateway" {
     "GET /some-route-with-authorizer-and-different-scope" = {
       lambda_arn             = module.lambda_function.lambda_function_arn
       payload_format_version = "2.0"
+      authorization_type     = "JWT"
       authorizer_key         = "cognito"
       authorization_scopes   = "tf/something.relevant.write" # Should comply with the resource server configuration part of the cognito user pool
     }

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -69,12 +69,13 @@ module "api_gateway" {
     }
 
     "GET /some-route" = {
-      lambda_arn             = module.lambda_function.lambda_function_arn
-      payload_format_version = "2.0"
-      authorization_type     = "JWT"
-      authorizer_id          = aws_apigatewayv2_authorizer.some_authorizer.id
-      throttling_rate_limit  = 80
-      throttling_burst_limit = 40
+      lambda_arn               = module.lambda_function.lambda_function_arn
+      payload_format_version   = "2.0"
+      authorization_type       = "JWT"
+      authorizer_id            = aws_apigatewayv2_authorizer.some_authorizer.id
+      throttling_rate_limit    = 80
+      throttling_burst_limit   = 40
+      detailed_metrics_enabled = true
     }
 
     "GET /some-route-with-authorizer" = {

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -34,8 +34,8 @@ module "api_gateway" {
   }
 
   mutual_tls_authentication = {
-    truststore_uri     = "s3://${aws_s3_bucket.truststore.bucket}/${aws_s3_bucket_object.truststore.id}"
-    truststore_version = aws_s3_bucket_object.truststore.version_id
+    truststore_uri     = "s3://${aws_s3_bucket.truststore.bucket}/${aws_s3_object.truststore.id}"
+    truststore_version = aws_s3_object.truststore.version_id
   }
 
   domain_name                 = local.domain_name
@@ -265,7 +265,7 @@ resource "null_resource" "download_package" {
 
 module "lambda_function" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   function_name = "${random_pet.this.id}-lambda"
   description   = "My awesome lambda function"
@@ -294,7 +294,7 @@ resource "aws_s3_bucket" "truststore" {
   #  acl    = "private"
 }
 
-resource "aws_s3_bucket_object" "truststore" {
+resource "aws_s3_object" "truststore" {
   bucket                 = aws_s3_bucket.truststore.bucket
   key                    = "truststore.pem"
   server_side_encryption = "AES256"

--- a/main.tf
+++ b/main.tf
@@ -80,26 +80,25 @@ resource "aws_apigatewayv2_stage" "default" {
     for_each = length(keys(var.default_route_settings)) == 0 ? [] : [var.default_route_settings]
 
     content {
-      data_trace_enabled       = try(default_route_settings.value.data_trace_enabled, false)
+      data_trace_enabled       = try(default_route_settings.value.data_trace_enabled, false)  # supported in Websocket Gateway only
       detailed_metrics_enabled = try(default_route_settings.value.detailed_metrics_enabled, false)
-      logging_level            = try(default_route_settings.value.logging_level, null)
+      logging_level            = try(default_route_settings.value.logging_level, null) # supported in Websocket Gateway only
       throttling_burst_limit   = try(default_route_settings.value.throttling_burst_limit, null)
       throttling_rate_limit    = try(default_route_settings.value.throttling_rate_limit, null)
     }
   }
 
-  #  # bug - https://github.com/terraform-providers/terraform-provider-aws/issues/12893
-  #  dynamic "route_settings" {
-  #    for_each = var.create_routes_and_integrations ? var.integrations : {}
-  #    content {
-  #      route_key = route_settings.key
-  #      data_trace_enabled = try(route_settings.value.data_trace_enabled, null)
-  #      detailed_metrics_enabled         = try(route_settings.value.detailed_metrics_enabled, null)
-  #      logging_level         = try(route_settings.value.logging_level, null)  # Error: error updating API Gateway v2 stage ($default): BadRequestException: Execution logs are not supported on protocolType HTTP
-  #      throttling_burst_limit         = try(route_settings.value.throttling_burst_limit, null)
-  #      throttling_rate_limit         = try(route_settings.value.throttling_rate_limit, null)
-  #    }
-  #  }
+  dynamic "route_settings" {
+    for_each = var.create_routes_and_integrations ? { for k, v in var.integrations : k => v if length(compact([tostring(try(v.data_trace_enabled, "")), tostring(try(v.detailed_metrics_enabled, "")), tostring(try(v.logging_level, "")), tostring(try(v.throttling_rate_limit, "")), tostring(try(v.throttling_burst_limit, ""))])) > 0 } : {}
+    content {
+      route_key                = route_settings.key
+      data_trace_enabled       = try(route_settings.value.data_trace_enabled, try(var.default_route_settings["data_trace_enabled"], false))
+      detailed_metrics_enabled = try(route_settings.value.detailed_metrics_enabled, try(var.default_route_settings["detailed_metrics_enabled"], false))
+      logging_level            = try(route_settings.value.logging_level, try(var.default_route_settings["logging_level"], null))
+      throttling_burst_limit   = try(route_settings.value.throttling_burst_limit, try(var.default_route_settings["throttling_burst_limit"], null))
+      throttling_rate_limit    = try(route_settings.value.throttling_rate_limit, try(var.default_route_settings["throttling_rate_limit"], null))
+    }
+  }
 
   tags = merge(var.default_stage_tags, var.tags)
 

--- a/main.tf
+++ b/main.tf
@@ -80,9 +80,9 @@ resource "aws_apigatewayv2_stage" "default" {
     for_each = length(keys(var.default_route_settings)) == 0 ? [] : [var.default_route_settings]
 
     content {
-      data_trace_enabled       = try(default_route_settings.value.data_trace_enabled, false)  # supported in Websocket Gateway only
+      data_trace_enabled       = try(default_route_settings.value.data_trace_enabled, false) # supported in Websocket APIGateway only
       detailed_metrics_enabled = try(default_route_settings.value.detailed_metrics_enabled, false)
-      logging_level            = try(default_route_settings.value.logging_level, null) # supported in Websocket Gateway only
+      logging_level            = try(default_route_settings.value.logging_level, null) # supported in Websocket APIGateway only
       throttling_burst_limit   = try(default_route_settings.value.throttling_burst_limit, null)
       throttling_rate_limit    = try(default_route_settings.value.throttling_rate_limit, null)
     }


### PR DESCRIPTION
## Description
Enable route_settings in default stage
route_settings will override default_settings, So even I just want to set throttling_rate_limit on route "POST /test", I have to set the remaining variables to use default_route_settings values, otherwise it will be AWS default value not default_route_settings value. e.g detailed_metrics_enabled will become false.
- Enable route_settings and add only the route with at least one of the options:
data_trace_enabled, logging_level, throttling_burst_limit, throttling_rate_limit, detailed_metrics_enabled is not null
- set the remaining variables to use use default_route_settings values

## Motivation and Context
#78 

## Breaking Changes
No

## How Has This Been Tested?
I have tested and deployed to my company AWS environment.