### PR TITLE
docs: Update README Usage section to reflect array format for identity_sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module "api_gateway" {
   authorizers = {
     "azure" = {
       authorizer_type  = "JWT"
-      identity_sources = "$request.header.Authorization"
+      identity_sources = ["$request.header.Authorization"]
       name             = "azure-auth"
       jwt_configuration = {
         audience         = ["d6a38afd-45d6-4874-d1aa-3c5c558aqcc2"]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Changed `identity_sources` in `authorizers` from a string to an array of strings in the [Usage](https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2?tab=readme-ov-file#usage) section.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the README file, the `identity_sources` field in the `authorizers` section of the Usage example was incorrectly listed as a string.
According to the [module's specifications](https://registry.terraform.io/modules/terraform-aws-modules/apigateway-v2/aws/latest#input_authorizers), `identity_sources` should be an array of strings.

Here is an image of the error encountered with the current documentation:
<img width="1019" alt="screenshot 2024-07-11 19 24 29" src="https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/assets/74942852/546b9fec-9c37-4f50-8317-144ceb097984">


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
