### PR TITLE
fix: Remove websocket prefix from domain name output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -103,7 +103,7 @@ output "stage_id" {
 
 output "stage_domain_name" {
   description = "Domain name of the stage (useful for CloudFront distribution)"
-  value       = replace(try(aws_apigatewayv2_stage.this[0].invoke_url, ""), "/^https?://([^/]*).*/", "$1")
+  value       = replace(try(aws_apigatewayv2_stage.this[0].invoke_url, ""), "/^(wss?|https?)://([^/]*).*/", "$2")
 }
 
 output "stage_arn" {


### PR DESCRIPTION
## Description
Strip off the `wss://` prefix from the stage_domain_name output in the case of websocket api.  This should fix #117

## Motivation and Context
We want to use a single Cloudfront domain for all our services (S3, API Gateway HTTP, API Gateway Websocket). In order to configure the Cloudfront Origin you need to pass in a domain name.  I noticed that this value was not being set correctly.

## Breaking Changes
I don't believe anyone would be using the incorrect domain name for websocket.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
I ran against the websocket example before and after the change to verify that `stage_domain_name` is set correctly.
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
