### PR TITLE
feat: Allow hosted zone name to be passed in separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,14 @@ This will create records that allow users to access the API Gateway using the fo
 
 ## Specific Hosted Zone
 
-If you want to create the domain name in a specific hosted zone, you can use the `apex_domain_name` input parameter:
+If you want to create the domain name in a specific hosted zone, you can use the `hosted_zone_name` input parameter:
 
 ```hcl
 module "api_gateway" {
   source = "terraform-aws-modules/apigateway-v2/aws"
 
   ...
-  apex_domain_name = "api.mydomain.com"
+  hosted_zone_name = "api.mydomain.com"
   domain_name      = "prod.api.mydomain.com"
   ...
 }
@@ -214,7 +214,6 @@ module "api_gateway" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_apex_domain_name"></a> [apex\_domain\_name](#input\_apex\_domain\_name) | Optional domain name of the Hosted Zone where the domain should be created | `string` | `null` | no |
 | <a name="input_api_key_selection_expression"></a> [api\_key\_selection\_expression](#input\_api\_key\_selection\_expression) | An API key selection expression. Valid values: `$context.authorizer.usageIdentifierKey`, `$request.header.x-api-key`. Defaults to `$request.header.x-api-key`. Applicable for WebSocket APIs | `string` | `null` | no |
 | <a name="input_api_mapping_key"></a> [api\_mapping\_key](#input\_api\_mapping\_key) | The [API mapping key](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-mapping-template-reference.html) | `string` | `null` | no |
 | <a name="input_api_version"></a> [api\_version](#input\_api\_version) | A version identifier for the API. Must be between 1 and 64 characters in length | `string` | `null` | no |
@@ -235,6 +234,7 @@ module "api_gateway" {
 | <a name="input_domain_name_certificate_arn"></a> [domain\_name\_certificate\_arn](#input\_domain\_name\_certificate\_arn) | The ARN of an AWS-managed certificate that will be used by the endpoint for the domain name. AWS Certificate Manager is the only supported source | `string` | `null` | no |
 | <a name="input_domain_name_ownership_verification_certificate_arn"></a> [domain\_name\_ownership\_verification\_certificate\_arn](#input\_domain\_name\_ownership\_verification\_certificate\_arn) | ARN of the AWS-issued certificate used to validate custom domain ownership (when certificate\_arn is issued via an ACM Private CA or mutual\_tls\_authentication is configured with an ACM-imported certificate.) | `string` | `null` | no |
 | <a name="input_fail_on_warnings"></a> [fail\_on\_warnings](#input\_fail\_on\_warnings) | Whether warnings should return an error while API Gateway is creating or updating the resource using an OpenAPI specification. Defaults to `false`. Applicable for HTTP APIs | `bool` | `null` | no |
+| <a name="input_hosted_zone_name"></a> [hosted\_zone\_name](#input\_hosted\_zone\_name) | Optional domain name of the Hosted Zone where the domain should be created | `string` | `null` | no |
 | <a name="input_mutual_tls_authentication"></a> [mutual\_tls\_authentication](#input\_mutual\_tls\_authentication) | The mutual TLS authentication configuration for the domain name | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the API. Must be less than or equal to 128 characters in length | `string` | `""` | no |
 | <a name="input_protocol_type"></a> [protocol\_type](#input\_protocol\_type) | The API protocol. Valid values: `HTTP`, `WEBSOCKET` | `string` | `"HTTP"` | no |

--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ This will create records that allow users to access the API Gateway using the fo
 - `customer1.mydomain.com`
 - `customer2.mydomain.com`
 
+## Specific Hosted Zone
+
+If you want to create the domain name in a specific hosted zone, you can use the `domain_name_zone_name` input parameter:
+
+```hcl
+module "api_gateway" {
+  source = "terraform-aws-modules/apigateway-v2/aws"
+
+  ...
+  domain_name_zone_name = "api.mydomain.com"
+  domain_name           = "prod.api.mydomain.com"
+  ...
+}
+```
+
 ## Conditional Creation
 
 The following values are provided to toggle on/off creation of the associated resources as desired:
@@ -218,6 +233,7 @@ module "api_gateway" {
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name to use for API gateway | `string` | `""` | no |
 | <a name="input_domain_name_certificate_arn"></a> [domain\_name\_certificate\_arn](#input\_domain\_name\_certificate\_arn) | The ARN of an AWS-managed certificate that will be used by the endpoint for the domain name. AWS Certificate Manager is the only supported source | `string` | `null` | no |
 | <a name="input_domain_name_ownership_verification_certificate_arn"></a> [domain\_name\_ownership\_verification\_certificate\_arn](#input\_domain\_name\_ownership\_verification\_certificate\_arn) | ARN of the AWS-issued certificate used to validate custom domain ownership (when certificate\_arn is issued via an ACM Private CA or mutual\_tls\_authentication is configured with an ACM-imported certificate.) | `string` | `null` | no |
+| <a name="input_domain_name_zone_name"></a> [domain\_name\_zone\_name](#input\_domain\_name\_zone\_name) | The Hosted Zone name the domain should be created in. If not passed this falls back to `domain_name` | `string` | `null` | no |
 | <a name="input_fail_on_warnings"></a> [fail\_on\_warnings](#input\_fail\_on\_warnings) | Whether warnings should return an error while API Gateway is creating or updating the resource using an OpenAPI specification. Defaults to `false`. Applicable for HTTP APIs | `bool` | `null` | no |
 | <a name="input_mutual_tls_authentication"></a> [mutual\_tls\_authentication](#input\_mutual\_tls\_authentication) | The mutual TLS authentication configuration for the domain name | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the API. Must be less than or equal to 128 characters in length | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -122,15 +122,15 @@ This will create records that allow users to access the API Gateway using the fo
 
 ## Specific Hosted Zone
 
-If you want to create the domain name in a specific hosted zone, you can use the `domain_name_zone_name` input parameter:
+If you want to create the domain name in a specific hosted zone, you can use the `apex_domain_name` input parameter:
 
 ```hcl
 module "api_gateway" {
   source = "terraform-aws-modules/apigateway-v2/aws"
 
   ...
-  domain_name_zone_name = "api.mydomain.com"
-  domain_name           = "prod.api.mydomain.com"
+  apex_domain_name = "api.mydomain.com"
+  domain_name      = "prod.api.mydomain.com"
   ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ module "api_gateway" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_apex_domain_name"></a> [apex\_domain\_name](#input\_apex\_domain\_name) | Optional domain name of the Hosted Zone where the domain should be created | `string` | `null` | no |
 | <a name="input_api_key_selection_expression"></a> [api\_key\_selection\_expression](#input\_api\_key\_selection\_expression) | An API key selection expression. Valid values: `$context.authorizer.usageIdentifierKey`, `$request.header.x-api-key`. Defaults to `$request.header.x-api-key`. Applicable for WebSocket APIs | `string` | `null` | no |
 | <a name="input_api_mapping_key"></a> [api\_mapping\_key](#input\_api\_mapping\_key) | The [API mapping key](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-mapping-template-reference.html) | `string` | `null` | no |
 | <a name="input_api_version"></a> [api\_version](#input\_api\_version) | A version identifier for the API. Must be between 1 and 64 characters in length | `string` | `null` | no |
@@ -233,7 +234,6 @@ module "api_gateway" {
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name to use for API gateway | `string` | `""` | no |
 | <a name="input_domain_name_certificate_arn"></a> [domain\_name\_certificate\_arn](#input\_domain\_name\_certificate\_arn) | The ARN of an AWS-managed certificate that will be used by the endpoint for the domain name. AWS Certificate Manager is the only supported source | `string` | `null` | no |
 | <a name="input_domain_name_ownership_verification_certificate_arn"></a> [domain\_name\_ownership\_verification\_certificate\_arn](#input\_domain\_name\_ownership\_verification\_certificate\_arn) | ARN of the AWS-issued certificate used to validate custom domain ownership (when certificate\_arn is issued via an ACM Private CA or mutual\_tls\_authentication is configured with an ACM-imported certificate.) | `string` | `null` | no |
-| <a name="input_domain_name_zone_name"></a> [domain\_name\_zone\_name](#input\_domain\_name\_zone\_name) | The Hosted Zone name the domain should be created in. If not passed this falls back to `domain_name` | `string` | `null` | no |
 | <a name="input_fail_on_warnings"></a> [fail\_on\_warnings](#input\_fail\_on\_warnings) | Whether warnings should return an error while API Gateway is creating or updating the resource using an OpenAPI specification. Defaults to `false`. Applicable for HTTP APIs | `bool` | `null` | no |
 | <a name="input_mutual_tls_authentication"></a> [mutual\_tls\_authentication](#input\_mutual\_tls\_authentication) | The mutual TLS authentication configuration for the domain name | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the API. Must be less than or equal to 128 characters in length | `string` | `""` | no |

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -49,7 +49,9 @@ module "api_gateway" {
   }
 
   # Domain Name
-  domain_name           = var.domain_name
+  domain_name = var.domain_name
+  # Not strictly required, but handy if you want to create the domain within a specific zone
+  domain_name_zone_name = var.domain_name
   create_domain_records = true
   create_certificate    = true
 

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -49,9 +49,7 @@ module "api_gateway" {
   }
 
   # Domain Name
-  domain_name = var.domain_name
-  # Not strictly required, but handy if you want to create the domain within a specific zone
-  domain_name_zone_name = var.domain_name
+  domain_name           = var.domain_name
   create_domain_records = true
   create_certificate    = true
 

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ locals {
 data "aws_route53_zone" "this" {
   count = local.create_domain_name && var.create_domain_records ? 1 : 0
 
-  name = var.domain_name_zone_name != null ? var.domain_name_zone_name : local.stripped_domain_name
+  name = coalesce(var.apex_domain_name, local.stripped_domain_name)
 }
 
 resource "aws_route53_record" "this" {

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ locals {
 data "aws_route53_zone" "this" {
   count = local.create_domain_name && var.create_domain_records ? 1 : 0
 
-  name = local.stripped_domain_name
+  name = var.domain_name_zone_name != null ? var.domain_name_zone_name : local.stripped_domain_name
 }
 
 resource "aws_route53_record" "this" {

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ locals {
 data "aws_route53_zone" "this" {
   count = local.create_domain_name && var.create_domain_records ? 1 : 0
 
-  name = coalesce(var.apex_domain_name, local.stripped_domain_name)
+  name = coalesce(var.hosted_zone_name, local.stripped_domain_name)
 }
 
 resource "aws_route53_record" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -144,7 +144,7 @@ variable "domain_name" {
   default     = ""
 }
 
-variable "apex_domain_name" {
+variable "hosted_zone_name" {
   description = "Optional domain name of the Hosted Zone where the domain should be created"
   type        = string
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -144,8 +144,8 @@ variable "domain_name" {
   default     = ""
 }
 
-variable "domain_name_zone_name" {
-  description = "The Hosted Zone name the domain should be created in. If not passed this falls back to `domain_name`"
+variable "apex_domain_name" {
+  description = "Optional domain name of the Hosted Zone where the domain should be created"
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -144,6 +144,12 @@ variable "domain_name" {
   default     = ""
 }
 
+variable "domain_name_zone_name" {
+  description = "The Hosted Zone name the domain should be created in. If not passed this falls back to `domain_name`"
+  type        = string
+  default     = null
+}
+
 variable "domain_name_certificate_arn" {
   description = "The ARN of an AWS-managed certificate that will be used by the endpoint for the domain name. AWS Certificate Manager is the only supported source"
   type        = string

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -22,6 +22,7 @@ module "wrapper" {
   domain_name                                        = try(each.value.domain_name, var.defaults.domain_name, "")
   domain_name_certificate_arn                        = try(each.value.domain_name_certificate_arn, var.defaults.domain_name_certificate_arn, null)
   domain_name_ownership_verification_certificate_arn = try(each.value.domain_name_ownership_verification_certificate_arn, var.defaults.domain_name_ownership_verification_certificate_arn, null)
+  domain_name_zone_name                              = try(each.value.domain_name_zone_name, var.defaults.domain_name_zone_name, null)
   fail_on_warnings                                   = try(each.value.fail_on_warnings, var.defaults.fail_on_warnings, null)
   mutual_tls_authentication                          = try(each.value.mutual_tls_authentication, var.defaults.mutual_tls_authentication, {})
   name                                               = try(each.value.name, var.defaults.name, "")

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -3,7 +3,6 @@ module "wrapper" {
 
   for_each = var.items
 
-  apex_domain_name                                   = try(each.value.apex_domain_name, var.defaults.apex_domain_name, null)
   api_key_selection_expression                       = try(each.value.api_key_selection_expression, var.defaults.api_key_selection_expression, null)
   api_mapping_key                                    = try(each.value.api_mapping_key, var.defaults.api_mapping_key, null)
   api_version                                        = try(each.value.api_version, var.defaults.api_version, null)
@@ -24,6 +23,7 @@ module "wrapper" {
   domain_name_certificate_arn                        = try(each.value.domain_name_certificate_arn, var.defaults.domain_name_certificate_arn, null)
   domain_name_ownership_verification_certificate_arn = try(each.value.domain_name_ownership_verification_certificate_arn, var.defaults.domain_name_ownership_verification_certificate_arn, null)
   fail_on_warnings                                   = try(each.value.fail_on_warnings, var.defaults.fail_on_warnings, null)
+  hosted_zone_name                                   = try(each.value.hosted_zone_name, var.defaults.hosted_zone_name, null)
   mutual_tls_authentication                          = try(each.value.mutual_tls_authentication, var.defaults.mutual_tls_authentication, {})
   name                                               = try(each.value.name, var.defaults.name, "")
   protocol_type                                      = try(each.value.protocol_type, var.defaults.protocol_type, "HTTP")

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -3,6 +3,7 @@ module "wrapper" {
 
   for_each = var.items
 
+  apex_domain_name                                   = try(each.value.apex_domain_name, var.defaults.apex_domain_name, null)
   api_key_selection_expression                       = try(each.value.api_key_selection_expression, var.defaults.api_key_selection_expression, null)
   api_mapping_key                                    = try(each.value.api_mapping_key, var.defaults.api_mapping_key, null)
   api_version                                        = try(each.value.api_version, var.defaults.api_version, null)
@@ -22,7 +23,6 @@ module "wrapper" {
   domain_name                                        = try(each.value.domain_name, var.defaults.domain_name, "")
   domain_name_certificate_arn                        = try(each.value.domain_name_certificate_arn, var.defaults.domain_name_certificate_arn, null)
   domain_name_ownership_verification_certificate_arn = try(each.value.domain_name_ownership_verification_certificate_arn, var.defaults.domain_name_ownership_verification_certificate_arn, null)
-  domain_name_zone_name                              = try(each.value.domain_name_zone_name, var.defaults.domain_name_zone_name, null)
   fail_on_warnings                                   = try(each.value.fail_on_warnings, var.defaults.fail_on_warnings, null)
   mutual_tls_authentication                          = try(each.value.mutual_tls_authentication, var.defaults.mutual_tls_authentication, {})
   name                                               = try(each.value.name, var.defaults.name, "")


### PR DESCRIPTION
## Description
Allow users to explicitly pass the name of the hosted zone they would like the domain to be created in.

## Motivation and Context
This allows for use cases where the hosted zone is delegated from another account (e.g. `team-abc.acme.com`).
Within that hosted zone you might want to create another domain (`api.team-abc.acme.com`). This currently isn't possible because the module expects a hosted zone with the name as passed in `var.domain_name` to be present.

- Resolves #112
- Closes #120

## Breaking Changes
None, if the parameter isn't passed we just look up the hosted zone based on the `stripped_domain_name` as before.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have tested and validated the changes against my own project that was failing with the same error as laid out in the issue linked above.
- [x] I have executed `pre-commit run -a` on my pull request