### PR TITLE
fix: Defer to user-supplied input before disabling execute-api endpoint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ locals {
   is_websocket = var.protocol_type == "WEBSOCKET"
 
   create_routes_and_integrations = var.create && var.create_routes_and_integrations
+  disable_execute_api_endpoint   = var.disable_execute_api_endpoint != null ? var.disable_execute_api_endpoint : local.is_http && local.create_domain_name
 }
 
 ################################################################################
@@ -31,7 +32,7 @@ resource "aws_apigatewayv2_api" "this" {
   credentials_arn = local.is_http ? var.credentials_arn : null
   description     = var.description
   # https://docs.aws.amazon.com/apigateway/latest/developerguide/rest-api-disable-default-endpoint.html
-  disable_execute_api_endpoint = local.is_http && local.create_domain_name ? true : var.disable_execute_api_endpoint
+  disable_execute_api_endpoint = local.disable_execute_api_endpoint
   fail_on_warnings             = local.is_http ? var.fail_on_warnings : null
   name                         = var.name
   protocol_type                = var.protocol_type


### PR DESCRIPTION
## Description
Allow users to leave the default endpoint enabled when a custom domain is set.

## Motivation and Context
Setting the `disable_execute_api_endpoint` variable to `false` should leave the default endpoint enabled when a custom domain is set.
This change resolves terraform-aws-modules/terraform-aws-apigateway-v2#128
This change also preserves the existing behaviour of disabling the default endpoint when a custom domain is set & no value was given for the `disable_execute_api_endpoint` variable. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have used this change in my own Terraform module to see that the default endpoint was not disabled
- [x] I have executed `pre-commit run -a` on my pull request