### PR TITLE
fix: Pin acm module to source hash

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,8 +162,7 @@ locals {
 }
 
 module "acm" {
-  source  = "terraform-aws-modules/acm/aws"
-  version = "5.0.1"
+  source  = "git::https://github.com/terraform-aws-modules/terraform-aws-acm/.git?ref=f421377c87fe5207898adc0def87540fa07c2af4" # commit hash of v5.0.1
 
   create_certificate = local.create_domain_name && var.create_domain_records && local.create_certificate
 

--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,7 @@ locals {
 }
 
 module "acm" {
-  source  = "git::https://github.com/terraform-aws-modules/terraform-aws-acm/.git?ref=f421377c87fe5207898adc0def87540fa07c2af4" # commit hash of v5.0.1
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-acm.git?ref=f421377c87fe5207898adc0def87540fa07c2af4" # commit hash of v5.0.1
 
   create_certificate = local.create_domain_name && var.create_domain_records && local.create_certificate
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Pin the acm module to a source hash instead of just referencing a version number

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's best security practices to pin to a source hash instead of a version number.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This should not break backwards compatibility. In fact, this change should not affect the functionality of the module at all.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
