### PR TITLE
Fix. Now module can find between private hosted zone. Added private_zone bool variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ module "api_gateway" {
 | <a name="input_ip_address_type"></a> [ip\_address\_type](#input\_ip\_address\_type) | The IP address types that can invoke the API. Valid values: ipv4, dualstack. Use ipv4 to allow only IPv4 addresses to invoke your API, or use dualstack to allow both IPv4 and IPv6 addresses to invoke your API. Defaults to ipv4. | `string` | `null` | no |
 | <a name="input_mutual_tls_authentication"></a> [mutual\_tls\_authentication](#input\_mutual\_tls\_authentication) | The mutual TLS authentication configuration for the domain name | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the API. Must be less than or equal to 128 characters in length | `string` | `""` | no |
+| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Whether the hosted zone is private or not. `false` for public hosted zone. `true` for private hosted zone. | `bool` | `false` | no |
 | <a name="input_protocol_type"></a> [protocol\_type](#input\_protocol\_type) | The API protocol. Valid values: `HTTP`, `WEBSOCKET` | `string` | `"HTTP"` | no |
 | <a name="input_route_key"></a> [route\_key](#input\_route\_key) | Part of quick create. Specifies any route key. Applicable for HTTP APIs | `string` | `null` | no |
 | <a name="input_route_selection_expression"></a> [route\_selection\_expression](#input\_route\_selection\_expression) | The route selection expression for the API. Defaults to `$request.method $request.path` | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ locals {
 
 data "aws_route53_zone" "this" {
   count = local.create_domain_name && var.create_domain_records ? 1 : 0
-
+  private_zone = var.private_zone
   name = coalesce(var.hosted_zone_name, local.stripped_domain_name)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,12 @@ variable "hosted_zone_name" {
   default     = null
 }
 
+variable "private_zone" {
+  description = "Whether the hosted zone is private or not"
+  type        = bool
+  default     = false
+}
+
 variable "domain_name_certificate_arn" {
   description = "The ARN of an AWS-managed certificate that will be used by the endpoint for the domain name. AWS Certificate Manager is the only supported source"
   type        = string


### PR DESCRIPTION
## Description
main.tf
before:
data "aws_route53_zone" "this" {
  count = local.create_domain_name && var.create_domain_records ? 1 : 0

  name = coalesce(var.hosted_zone_name, local.stripped_domain_name)
}
now:
data "aws_route53_zone" "this" {
  count = local.create_domain_name && var.create_domain_records ? 1 : 0
  private_zone = var.private_zone
  name = coalesce(var.hosted_zone_name, local.stripped_domain_name)
}

variables.tf
added: 

line 159: variable "private_zone" {
  description = "Whether the hosted zone is private or not"
  type        = bool
  default     = false
}

## Motivation and Context
This is needed when someone wants to create records in a private hosted zone. The private_zone argument is required when looking up private zones using the aws_route53_zone data source. Without this parameter, Terraform cannot find the private zone, even if the zone name matches.

## Breaking Changes
This change introduces a new variable (private_zone) with a default value of false, so it is backward compatible.

However, users must explicitly set private_zone = true when creating records in a private hosted zone. Failing to do so will result in the zone not being found.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
