### PR TITLE
feat: Allows lookup of private hosted zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ module "api_gateway" {
 | <a name="input_body"></a> [body](#input\_body) | An OpenAPI specification that defines the set of routes and integrations to create as part of the HTTP APIs. Supported only for HTTP APIs | `string` | `null` | no |
 | <a name="input_cors_configuration"></a> [cors\_configuration](#input\_cors\_configuration) | The cross-origin resource sharing (CORS) configuration. Applicable for HTTP APIs | <pre>object({<br/>    allow_credentials = optional(bool)<br/>    allow_headers     = optional(list(string))<br/>    allow_methods     = optional(list(string))<br/>    allow_origins     = optional(list(string))<br/>    expose_headers    = optional(list(string), [])<br/>    max_age           = optional(number)<br/>  })</pre> | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created | `bool` | `true` | no |
-| <a name="input_create_certificate"></a> [create\_certificate](#input\_create\_certificate) | Whether to create a certificate for the domain | `bool` | `true` | no |
+| <a name="input_create_certificate"></a> [create\_certificate](#input\_create\_certificate) | Whether to create a certificate for the domain.  Since certificate validate only works on public domains, this will be ignore if `private_zone` is set to `true` | `bool` | `true` | no |
 | <a name="input_create_domain_name"></a> [create\_domain\_name](#input\_create\_domain\_name) | Whether to create API domain name resource | `bool` | `true` | no |
 | <a name="input_create_domain_records"></a> [create\_domain\_records](#input\_create\_domain\_records) | Whether to create Route53 records for the domain name | `bool` | `true` | no |
 | <a name="input_create_routes_and_integrations"></a> [create\_routes\_and\_integrations](#input\_create\_routes\_and\_integrations) | Whether to create routes and integrations resources | `bool` | `true` | no |
@@ -237,7 +237,7 @@ module "api_gateway" {
 | <a name="input_hosted_zone_name"></a> [hosted\_zone\_name](#input\_hosted\_zone\_name) | Optional domain name of the Hosted Zone where the domain should be created | `string` | `null` | no |
 | <a name="input_mutual_tls_authentication"></a> [mutual\_tls\_authentication](#input\_mutual\_tls\_authentication) | The mutual TLS authentication configuration for the domain name | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the API. Must be less than or equal to 128 characters in length | `string` | `""` | no |
-| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Indicates the hosted zone being looked up is private. | `bool` | `false` | no |
+| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Indicates the hosted zone being looked up is private.  Certificate validation will fail if this is set to true. | `bool` | `false` | no |
 | <a name="input_protocol_type"></a> [protocol\_type](#input\_protocol\_type) | The API protocol. Valid values: `HTTP`, `WEBSOCKET` | `string` | `"HTTP"` | no |
 | <a name="input_route_key"></a> [route\_key](#input\_route\_key) | Part of quick create. Specifies any route key. Applicable for HTTP APIs | `string` | `null` | no |
 | <a name="input_route_selection_expression"></a> [route\_selection\_expression](#input\_route\_selection\_expression) | The route selection expression for the API. Defaults to `$request.method $request.path` | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ module "api_gateway" {
 | <a name="input_hosted_zone_name"></a> [hosted\_zone\_name](#input\_hosted\_zone\_name) | Optional domain name of the Hosted Zone where the domain should be created | `string` | `null` | no |
 | <a name="input_mutual_tls_authentication"></a> [mutual\_tls\_authentication](#input\_mutual\_tls\_authentication) | The mutual TLS authentication configuration for the domain name | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the API. Must be less than or equal to 128 characters in length | `string` | `""` | no |
+| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Indicates the hosted zone being looked up is private. | `bool` | `false` | no |
 | <a name="input_protocol_type"></a> [protocol\_type](#input\_protocol\_type) | The API protocol. Valid values: `HTTP`, `WEBSOCKET` | `string` | `"HTTP"` | no |
 | <a name="input_route_key"></a> [route\_key](#input\_route\_key) | Part of quick create. Specifies any route key. Applicable for HTTP APIs | `string` | `null` | no |
 | <a name="input_route_selection_expression"></a> [route\_selection\_expression](#input\_route\_selection\_expression) | The route selection expression for the API. Defaults to `$request.method $request.path` | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -157,7 +157,7 @@ resource "aws_route53_record" "this" {
 ################################################################################
 
 locals {
-  create_certificate = local.create_domain_name && var.create_certificate
+  create_certificate = local.create_domain_name && var.create_certificate && !var.private_zone
 
   is_wildcard = startswith(var.domain_name, "*.")
 }

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,8 @@ locals {
 data "aws_route53_zone" "this" {
   count = local.create_domain_name && var.create_domain_records ? 1 : 0
 
-  name = coalesce(var.hosted_zone_name, local.stripped_domain_name)
+  name         = coalesce(var.hosted_zone_name, local.stripped_domain_name)
+  private_zone = var.private_zone
 }
 
 resource "aws_route53_record" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -151,7 +151,7 @@ variable "hosted_zone_name" {
 }
 
 variable "private_zone" {
-  description = "Indicates the hosted zone being looked up is private."
+  description = "Indicates the hosted zone being looked up is private.  Certificate validation will fail if this is set to true."
   type        = bool
   default     = false
 }
@@ -201,7 +201,7 @@ variable "subdomain_record_types" {
 ################################################################################
 
 variable "create_certificate" {
-  description = "Whether to create a certificate for the domain"
+  description = "Whether to create a certificate for the domain.  Since certificate validate only works on public domains, this will be ignore if `private_zone` is set to `true`"
   type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -150,6 +150,12 @@ variable "hosted_zone_name" {
   default     = null
 }
 
+variable "private_zone" {
+  description = "Indicates the hosted zone being looked up is private."
+  type        = bool
+  default     = false
+}
+
 variable "domain_name_certificate_arn" {
   description = "The ARN of an AWS-managed certificate that will be used by the endpoint for the domain name. AWS Certificate Manager is the only supported source"
   type        = string

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -26,6 +26,7 @@ module "wrapper" {
   hosted_zone_name                                   = try(each.value.hosted_zone_name, var.defaults.hosted_zone_name, null)
   mutual_tls_authentication                          = try(each.value.mutual_tls_authentication, var.defaults.mutual_tls_authentication, {})
   name                                               = try(each.value.name, var.defaults.name, "")
+  private_zone                                       = try(each.value.private_zone, var.defaults.private_zone, false)
   protocol_type                                      = try(each.value.protocol_type, var.defaults.protocol_type, "HTTP")
   route_key                                          = try(each.value.route_key, var.defaults.route_key, null)
   route_selection_expression                         = try(each.value.route_selection_expression, var.defaults.route_selection_expression, null)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Adds a `private_zone` input and passes along to the DNS zone lookup.

Note that certificate validation and private_zone are mutually exclusive as AWS cert validation requires public DNS records.  Something we do is create the private DNS zone and then create a public DNS entry for the validation but requires the private zone to be a subdomain of a public one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Our sandbox account does not have a public DNS zone and we would like to use this module using our private DNS.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I do not believe there is a way I can add to the examples without expecting both a public and private DNS domain.  I can add a variable for the private domain, but then it requires two domains.  I can do so if desired.

As for testing this against something, we are currently using this for our API Gateway with a private DNS.