### PR TITLE
fix: Update stage_access_logs_cloudwatch_log_group outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -127,12 +127,12 @@ output "stage_invoke_url" {
 
 output "stage_access_logs_cloudwatch_log_group_name" {
   description = "Name of cloudwatch log group created"
-  value       = try(aws_cloudwatch_log_group.this[0].name, null)
+  value       = try(aws_cloudwatch_log_group.this["this"].name, null)
 }
 
 output "stage_access_logs_cloudwatch_log_group_arn" {
   description = "Arn of cloudwatch log group created"
-  value       = try(aws_cloudwatch_log_group.this[0].arn, null)
+  value       = try(aws_cloudwatch_log_group.this["this"].arn, null)
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
Fixed null value outputs for stage access logs CloudWatch log group

## Motivation and Context
Fixing broken output values; the change is made in accordance with the resource relocation: https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/blob/5d1548624b39145ead043794ae5762abb9aadb27/migrations.tf#L10-L13

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
