### PR TITLE
feat: Trigger redeploy when Authorizers change

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -391,6 +391,7 @@ resource "aws_apigatewayv2_deployment" "this" {
       jsonencode(aws_apigatewayv2_route.this),
       jsonencode(aws_apigatewayv2_route_response.this),
       jsonencode(aws_apigatewayv2_api.this[0].body),
+      jsonencode(aws_apigatewayv2_authorizer.this),
     ])))
   }
 


### PR DESCRIPTION
## Description
Trigger redeployment when any of the authorizers change.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I ran into this edge case - the authorizer changes (_when changing the `authorizer_uri`, for example_) were not reflected until I redeployed the API.

Based on the official AWS documentation [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html) and [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-set-up-websocket-deployment.html ) (_check the red warning box_), the API has to be redeployed so the changes can be reflected.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
