### PR TITLE
docs: Add AWS_IAM authorization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ module "api_gateway" {
       }
     }
 
+    "GET /some-route-with-iam" = {
+      authorization_type = "AWS_IAM"
+
+      integration = {
+        uri = "arn:aws:lambda:eu-west-1:052235179155:function:my-function"
+      }
+    }
+
     "$default" = {
       integration = {
         uri = "arn:aws:lambda:eu-west-1:052235179155:function:my-default-function"

--- a/examples/complete-http/main.tf
+++ b/examples/complete-http/main.tf
@@ -104,6 +104,14 @@ module "api_gateway" {
       }
     }
 
+    "GET /some-route-with-iam" = {
+      authorization_type = "AWS_IAM"
+
+      integration = {
+        uri = module.lambda_function.lambda_function_arn
+      }
+    }
+
     "POST /start-step-function" = {
       integration = {
         type            = "AWS_PROXY"


### PR DESCRIPTION
## Description
Adds documentation and a working example for using `authorization_type = "AWS_IAM"` with API Gateway HTTP APIs. This includes:
- A new route example in `examples/complete-http/main.tf` demonstrating AWS_IAM authorization
- Updated main `README.md` with a concise AWS_IAM usage example

## Motivation and Context
Closes #86

I was struggling to understand how to configure AWS_IAM authorization for API Gateway routes. The existing documentation didn't include any examples of this authorization type, making it unclear how to set up the route with authorization_type  IAM.

## Breaking Changes
None - this is a documentation-only enhancement.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
